### PR TITLE
Fix README typos and update unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Analyze GitHub Actions workflow performance and generate Chrome Tracing format o
 
 
 ### Perfetto UI
-Example from one of Nodejs's GHA runs
+Example from one of Node.js’s GHA runs
 
 <img width="1626" height="1042" alt="image" src="https://github.com/user-attachments/assets/7ebf33cb-5caf-4233-9e0d-c5f562a8e6ef" />
 
@@ -234,17 +234,16 @@ node --test test/helpers.test.mjs
 ```
 ├── main.mjs              # Main profiler script
 ├── test/
-│   ├── main.test.mjs     # Integration tests
-│   ├── helpers.test.mjs  # Unit tests
-│   ├── github-mock.mjs   # API mocking utilities
-│   └── debug.mjs         # Debug utilities
+│   ├── consolidated.test.mjs  # Integration tests
+│   ├── unit.test.mjs          # Unit tests
+│   └── github-mock.mjs        # API mocking utilities
 ├── package.json          # Project configuration
-└── README.md            # This file
+└── README.md             # This file
 ```
 
 ### Adding Features
 1. Add functionality to `main.mjs`
-2. Add tests to `test/helpers.test.mjs`
+2. Add tests to `test/unit.test.mjs`
 3. Update documentation
 4. Run tests: `npm test`
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node main.mjs",
     "test": "node --test test/*.test.mjs",
-    "test:unit": "node --test test/unit-tests.mjs",
+    "test:unit": "node --test test/unit.test.mjs",
     "test:integration": "node --test test/consolidated.test.mjs",
     "test:watch": "node --test --watch test/*.test.mjs",
     "lint": "echo 'No linter configured - consider adding ESLint'",

--- a/test/unit.test.mjs
+++ b/test/unit.test.mjs
@@ -275,14 +275,20 @@ describe('Job Analysis Functions', () => {
           { name: 'Step4', duration: 8000 }
         ]
       };
-      
+
       const slowSteps = analyzeSlowSteps(mockMetrics, 2);
-      
+
       assert.strictEqual(slowSteps.length, 2);
       assert.strictEqual(slowSteps[0].name, 'Step4');
       assert.strictEqual(slowSteps[0].duration, 8000);
       assert.strictEqual(slowSteps[1].name, 'Step2');
       assert.strictEqual(slowSteps[1].duration, 5000);
+    });
+
+    test('should handle empty input', () => {
+      const mockMetrics = { stepDurations: [] };
+      const slowSteps = analyzeSlowSteps(mockMetrics);
+      assert.strictEqual(slowSteps.length, 0);
     });
   });
 


### PR DESCRIPTION
## Summary
- fix Node.js spelling and project structure details in README
- correct unit test script path
- add empty-input case for analyzeSlowSteps

## Testing
- `npm test` *(fails: should handle analyzer execution gracefully)*
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6895071ecfd08329b5adb3bcd23eb8c8