### PR TITLE
Clean up trends feature: add tests, fix code quality

### DIFF
--- a/cmd/gha-analyzer/main.go
+++ b/cmd/gha-analyzer/main.go
@@ -245,15 +245,7 @@ func main() {
 		}
 		owner, repo := parts[0], parts[1]
 
-		// Get GitHub token
-		token := os.Getenv("GITHUB_TOKEN")
-		if token == "" {
-			if ghPath, err := exec.LookPath("gh"); err == nil {
-				if out, err := exec.Command(ghPath, "auth", "token").Output(); err == nil {
-					token = strings.TrimSpace(string(out))
-				}
-			}
-		}
+		token := resolveGitHubToken()
 		if token == "" {
 			printErrorMsg("GITHUB_TOKEN environment variable is required.\n  Tip: install the GitHub CLI (gh) and run `gh auth login` to authenticate automatically.")
 			os.Exit(1)
@@ -321,26 +313,17 @@ func main() {
 	}
 
 	// 1. Setup GitHub Token
-	token := os.Getenv("GITHUB_TOKEN")
+	token := resolveGitHubToken()
 	if token == "" {
+		// Fall back to parsing token from positional args (legacy behavior)
 		for i, arg := range args {
 			if !strings.HasPrefix(arg, "http") && !strings.HasPrefix(arg, "-") {
-				// Skip arguments that look like GitHub URLs (shorthand or full)
 				if _, err := utils.ParseGitHubURL(arg); err == nil {
 					continue
 				}
 				token = arg
 				args = append(args[:i], args[i+1:]...)
 				break
-			}
-		}
-	}
-
-	// Fall back to `gh auth token` if gh CLI is available
-	if token == "" {
-		if ghPath, err := exec.LookPath("gh"); err == nil {
-			if out, err := exec.Command(ghPath, "auth", "token").Output(); err == nil {
-				token = strings.TrimSpace(string(out))
 			}
 		}
 	}
@@ -594,6 +577,19 @@ func printUsage() {
 	fmt.Println("  gha-analyzer trends owner/repo --days=7 --format=json")
 	fmt.Println("  gha-analyzer trends owner/repo --branch=main --workflow=post-merge.yaml")
 	fmt.Println("  gha-analyzer --clear-cache")
+}
+
+// resolveGitHubToken returns a GitHub token from GITHUB_TOKEN env var or gh CLI.
+func resolveGitHubToken() string {
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		return token
+	}
+	if ghPath, err := exec.LookPath("gh"); err == nil {
+		if out, err := exec.Command(ghPath, "auth", "token").Output(); err == nil {
+			return strings.TrimSpace(string(out))
+		}
+	}
+	return ""
 }
 
 // isTerminal checks if stdout and stderr are connected to a terminal

--- a/pkg/analyzer/BUILD.bazel
+++ b/pkg/analyzer/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "data_provider_test.go",
         "metrics_test.go",
         "otel_test.go",
+        "trends_test.go",
     ],
     embed = [":analyzer"],
     deps = [

--- a/pkg/analyzer/otel_test.go
+++ b/pkg/analyzer/otel_test.go
@@ -67,6 +67,11 @@ func (m *mockGitHubProvider) FetchBranchProtection(ctx context.Context, owner, r
 	return args.Get(0).(*githubapi.BranchProtection), args.Error(1)
 }
 
+func (m *mockGitHubProvider) FetchRecentWorkflowRuns(ctx context.Context, owner, repo string, days int, branch, workflow string) ([]githubapi.WorkflowRun, error) {
+	args := m.Called(ctx, owner, repo, days, branch, workflow)
+	return args.Get(0).([]githubapi.WorkflowRun), args.Error(1)
+}
+
 func TestOTelSpanGeneration(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/analyzer/trends.go
+++ b/pkg/analyzer/trends.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stefanpenner/gha-analyzer/pkg/utils"
 )
 
-// TrendAnalysis contains trend data for a repository
+// TrendAnalysis holds the result of analyzing historical workflow trends for a repository.
 type TrendAnalysis struct {
 	Owner            string
 	Repo             string
@@ -162,10 +162,10 @@ func AnalyzeTrends(ctx context.Context, client githubapi.GitHubProvider, owner, 
 	analysis.Summary = calculateTrendSummary(runData)
 
 	// Generate duration trend
-	analysis.DurationTrend = generateDurationTrend(runData, days)
+	analysis.DurationTrend = generateDurationTrend(runData)
 
 	// Generate success rate trend
-	analysis.SuccessRateTrend = generateSuccessRateTrend(runData, days)
+	analysis.SuccessRateTrend = generateSuccessRateTrend(runData)
 
 	// Analyze individual jobs
 	analysis.JobTrends = analyzeJobTrends(runData)
@@ -299,7 +299,7 @@ func calculateTrendSummary(runs []RunData) TrendSummary {
 }
 
 // generateDurationTrend creates time-series data for duration
-func generateDurationTrend(runs []RunData, days int) []DataPoint {
+func generateDurationTrend(runs []RunData) []DataPoint {
 	dayBuckets := make(map[string][]float64)
 
 	for _, run := range runs {
@@ -329,7 +329,7 @@ func generateDurationTrend(runs []RunData, days int) []DataPoint {
 }
 
 // generateSuccessRateTrend creates time-series data for success rate
-func generateSuccessRateTrend(runs []RunData, days int) []DataPoint {
+func generateSuccessRateTrend(runs []RunData) []DataPoint {
 	dayBuckets := make(map[string]struct{ success, total int })
 
 	for _, run := range runs {

--- a/pkg/analyzer/trends_test.go
+++ b/pkg/analyzer/trends_test.go
@@ -1,0 +1,275 @@
+package analyzer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makeRunData(conclusion string, durationMs int64, createdAt time.Time, jobs []JobData) RunData {
+	return RunData{
+		ID:         1,
+		Status:     "completed",
+		Conclusion: conclusion,
+		CreatedAt:  createdAt,
+		UpdatedAt:  createdAt.Add(time.Duration(durationMs) * time.Millisecond),
+		Duration:   durationMs,
+		Jobs:       jobs,
+	}
+}
+
+func TestCalculateTrendSummary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty runs", func(t *testing.T) {
+		summary := calculateTrendSummary(nil)
+		assert.Equal(t, 0, summary.TotalRuns)
+		assert.Equal(t, 0.0, summary.AvgDuration)
+	})
+
+	t.Run("single run", func(t *testing.T) {
+		runs := []RunData{
+			makeRunData("success", 60000, time.Now(), nil),
+		}
+		summary := calculateTrendSummary(runs)
+		assert.Equal(t, 1, summary.TotalRuns)
+		assert.Equal(t, 60.0, summary.AvgDuration)
+		assert.Equal(t, 100.0, summary.AvgSuccessRate)
+		assert.Equal(t, "stable", summary.TrendDirection)
+	})
+
+	t.Run("mixed success and failure", func(t *testing.T) {
+		runs := []RunData{
+			makeRunData("success", 60000, time.Now(), nil),
+			makeRunData("failure", 30000, time.Now(), nil),
+			makeRunData("success", 90000, time.Now(), nil),
+			makeRunData("failure", 45000, time.Now(), nil),
+		}
+		summary := calculateTrendSummary(runs)
+		assert.Equal(t, 4, summary.TotalRuns)
+		assert.Equal(t, 50.0, summary.AvgSuccessRate)
+	})
+
+	t.Run("improving trend", func(t *testing.T) {
+		// First half slow, second half fast
+		runs := []RunData{
+			makeRunData("success", 100000, time.Now(), nil),
+			makeRunData("success", 100000, time.Now(), nil),
+			makeRunData("success", 50000, time.Now(), nil),
+			makeRunData("success", 50000, time.Now(), nil),
+		}
+		summary := calculateTrendSummary(runs)
+		assert.Equal(t, "improving", summary.TrendDirection)
+		assert.Less(t, summary.PercentChange, -5.0)
+	})
+
+	t.Run("degrading trend", func(t *testing.T) {
+		// First half fast, second half slow
+		runs := []RunData{
+			makeRunData("success", 50000, time.Now(), nil),
+			makeRunData("success", 50000, time.Now(), nil),
+			makeRunData("success", 100000, time.Now(), nil),
+			makeRunData("success", 100000, time.Now(), nil),
+		}
+		summary := calculateTrendSummary(runs)
+		assert.Equal(t, "degrading", summary.TrendDirection)
+		assert.Greater(t, summary.PercentChange, 5.0)
+	})
+}
+
+func TestGenerateDurationTrend(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty runs", func(t *testing.T) {
+		points := generateDurationTrend(nil)
+		assert.Empty(t, points)
+	})
+
+	t.Run("groups by day", func(t *testing.T) {
+		day1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+		day2 := time.Date(2026, 1, 2, 10, 0, 0, 0, time.UTC)
+		runs := []RunData{
+			makeRunData("success", 60000, day1, nil),
+			makeRunData("success", 120000, day1, nil),
+			makeRunData("success", 180000, day2, nil),
+		}
+		points := generateDurationTrend(runs)
+		assert.Len(t, points, 2)
+		// Points should be sorted by time
+		assert.True(t, points[0].Timestamp.Before(points[1].Timestamp))
+	})
+}
+
+func TestGenerateSuccessRateTrend(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty runs", func(t *testing.T) {
+		points := generateSuccessRateTrend(nil)
+		assert.Empty(t, points)
+	})
+
+	t.Run("calculates daily success rate", func(t *testing.T) {
+		day1 := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+		runs := []RunData{
+			makeRunData("success", 60000, day1, nil),
+			makeRunData("failure", 60000, day1, nil),
+		}
+		points := generateSuccessRateTrend(runs)
+		assert.Len(t, points, 1)
+		assert.Equal(t, 50.0, points[0].Value)
+		assert.Equal(t, 2, points[0].Count)
+	})
+}
+
+func TestDetectFlakyJobs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no runs", func(t *testing.T) {
+		flakyJobs := detectFlakyJobs(nil)
+		assert.Empty(t, flakyJobs)
+	})
+
+	t.Run("too few runs ignored", func(t *testing.T) {
+		now := time.Now()
+		runs := []RunData{
+			{Jobs: []JobData{{Name: "test", Conclusion: "failure", CompletedAt: now}}},
+			{Jobs: []JobData{{Name: "test", Conclusion: "failure", CompletedAt: now}}},
+		}
+		flakyJobs := detectFlakyJobs(runs)
+		assert.Empty(t, flakyJobs)
+	})
+
+	t.Run("detects flaky job above threshold", func(t *testing.T) {
+		now := time.Now()
+		runs := make([]RunData, 10)
+		for i := range runs {
+			conclusion := "success"
+			if i < 3 { // 30% failure rate
+				conclusion = "failure"
+			}
+			runs[i] = RunData{Jobs: []JobData{{
+				Name:        "test",
+				Conclusion:  conclusion,
+				CompletedAt: now.Add(time.Duration(i) * time.Hour),
+			}}}
+		}
+		flakyJobs := detectFlakyJobs(runs)
+		assert.Len(t, flakyJobs, 1)
+		assert.Equal(t, "test", flakyJobs[0].Name)
+		assert.Equal(t, 30.0, flakyJobs[0].FlakeRate)
+	})
+
+	t.Run("ignores stable jobs below threshold", func(t *testing.T) {
+		now := time.Now()
+		runs := make([]RunData, 20)
+		for i := range runs {
+			conclusion := "success"
+			if i == 0 { // 5% failure rate
+				conclusion = "failure"
+			}
+			runs[i] = RunData{Jobs: []JobData{{
+				Name:        "test",
+				Conclusion:  conclusion,
+				CompletedAt: now.Add(time.Duration(i) * time.Hour),
+			}}}
+		}
+		flakyJobs := detectFlakyJobs(runs)
+		assert.Empty(t, flakyJobs)
+	})
+}
+
+func TestCalculateJobChanges(t *testing.T) {
+	t.Parallel()
+
+	t.Run("too few runs", func(t *testing.T) {
+		regressions, improvements := calculateJobChanges([]RunData{{}, {}})
+		assert.Nil(t, regressions)
+		assert.Nil(t, improvements)
+	})
+
+	t.Run("detects regression", func(t *testing.T) {
+		runs := []RunData{
+			{Jobs: []JobData{{Name: "build", Duration: 10000}}},
+			{Jobs: []JobData{{Name: "build", Duration: 10000}}},
+			{Jobs: []JobData{{Name: "build", Duration: 20000}}},
+			{Jobs: []JobData{{Name: "build", Duration: 20000}}},
+		}
+		regressions, improvements := calculateJobChanges(runs)
+		assert.Len(t, regressions, 1)
+		assert.Equal(t, "build", regressions[0].Name)
+		assert.Greater(t, regressions[0].PercentIncrease, 10.0)
+		assert.Empty(t, improvements)
+	})
+
+	t.Run("detects improvement", func(t *testing.T) {
+		runs := []RunData{
+			{Jobs: []JobData{{Name: "build", Duration: 20000}}},
+			{Jobs: []JobData{{Name: "build", Duration: 20000}}},
+			{Jobs: []JobData{{Name: "build", Duration: 10000}}},
+			{Jobs: []JobData{{Name: "build", Duration: 10000}}},
+		}
+		regressions, improvements := calculateJobChanges(runs)
+		assert.Empty(t, regressions)
+		assert.Len(t, improvements, 1)
+		assert.Equal(t, "build", improvements[0].Name)
+		assert.Greater(t, improvements[0].PercentDecrease, 10.0)
+	})
+
+	t.Run("ignores small changes", func(t *testing.T) {
+		runs := []RunData{
+			{Jobs: []JobData{{Name: "build", Duration: 10000}}},
+			{Jobs: []JobData{{Name: "build", Duration: 10000}}},
+			{Jobs: []JobData{{Name: "build", Duration: 10500}}},
+			{Jobs: []JobData{{Name: "build", Duration: 10500}}},
+		}
+		regressions, improvements := calculateJobChanges(runs)
+		assert.Empty(t, regressions)
+		assert.Empty(t, improvements)
+	})
+}
+
+func TestCalculateQueueTimeStats(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty runs", func(t *testing.T) {
+		stats := calculateQueueTimeStats(nil)
+		assert.Equal(t, 0.0, stats.AvgQueueTime)
+	})
+
+	t.Run("calculates queue stats", func(t *testing.T) {
+		runs := []RunData{
+			{Jobs: []JobData{
+				{QueueTime: 5000, Duration: 60000},
+				{QueueTime: 3000, Duration: 30000},
+			}},
+		}
+		stats := calculateQueueTimeStats(runs)
+		assert.Equal(t, 4.0, stats.AvgQueueTime) // (5+3)/2 seconds
+		assert.Equal(t, 45.0, stats.AvgRunTime)   // (60+30)/2 seconds
+		assert.Greater(t, stats.QueueTimeRatio, 0.0)
+		assert.Less(t, stats.QueueTimeRatio, 100.0)
+	})
+}
+
+func TestStatisticalFunctions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("average", func(t *testing.T) {
+		assert.Equal(t, 0.0, average(nil))
+		assert.Equal(t, 2.0, average([]float64{1, 2, 3}))
+	})
+
+	t.Run("calculateMedian", func(t *testing.T) {
+		assert.Equal(t, 0.0, calculateMedian(nil))
+		assert.Equal(t, 2.0, calculateMedian([]float64{1, 2, 3}))
+		assert.Equal(t, 2.5, calculateMedian([]float64{1, 2, 3, 4}))
+	})
+
+	t.Run("calculatePercentile", func(t *testing.T) {
+		assert.Equal(t, 0.0, calculatePercentile(nil, 95))
+		values := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+		p95 := calculatePercentile(values, 95)
+		assert.Equal(t, 10.0, p95)
+	})
+}

--- a/pkg/output/trends.go
+++ b/pkg/output/trends.go
@@ -313,46 +313,6 @@ func outputTrendsJSON(w io.Writer, analysis *analyzer.TrendAnalysis) error {
 	return encoder.Encode(analysis)
 }
 
-// Additional helper for sparkline (compact inline chart)
-func generateSparkline(points []analyzer.DataPoint) string {
-	if len(points) == 0 {
-		return ""
-	}
-
-	// Sparkline characters from low to high
-	chars := []rune{'▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'}
-
-	minVal := points[0].Value
-	maxVal := points[0].Value
-	for _, p := range points {
-		if p.Value < minVal {
-			minVal = p.Value
-		}
-		if p.Value > maxVal {
-			maxVal = p.Value
-		}
-	}
-
-	valueRange := maxVal - minVal
-	if valueRange == 0 {
-		return string(chars[len(chars)/2])
-	}
-
-	var sb strings.Builder
-	for _, p := range points {
-		normalized := (p.Value - minVal) / valueRange
-		idx := int(normalized * float64(len(chars)-1))
-		if idx < 0 {
-			idx = 0
-		}
-		if idx >= len(chars) {
-			idx = len(chars) - 1
-		}
-		sb.WriteRune(chars[idx])
-	}
-
-	return sb.String()
-}
 func renderQueueTimeStats(w io.Writer, stats analyzer.QueueTimeStats) {
 	fmt.Fprintf(w, "\n%-25s %20s\n", "Metric", "Value")
 	fmt.Fprintf(w, "%s\n", strings.Repeat("-", 50))


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for trends analysis (trends_test.go)
- Fix missing FetchRecentWorkflowRuns in mock (otel_test.go compilation error)
- Remove unused generateSparkline function
- Remove unused `days` parameter from internal functions
- Extract `resolveGitHubToken()` helper to deduplicate token resolution

## Test plan
- [x] `bazel test //...` passes (9/9 tests)

Stacked on #24 — merge this first, then #24 into main.