### PR TITLE
OTel-native enrichment with trace input and 7 analysis features

### DIFF
--- a/cmd/gha-analyzer/main.go
+++ b/cmd/gha-analyzer/main.go
@@ -104,6 +104,7 @@ type config struct {
 	trendsNoSample   bool
 	trendsConfidence float64
 	trendsMargin     float64
+	noArtifacts      bool
 }
 
 func parseArgs(args []string, terminal bool) (config, error) {
@@ -200,6 +201,10 @@ func parseArgs(args []string, terminal bool) (config, error) {
 			cfg.clearCache = true
 			continue
 		}
+		if arg == "--no-artifacts" {
+			cfg.noArtifacts = true
+			continue
+		}
 
 		// Trends-specific flags
 		if strings.HasPrefix(arg, "--days=") {
@@ -251,6 +256,15 @@ func parseArgs(args []string, terminal bool) (config, error) {
 		if cfg.trendsMode && cfg.trendsRepo == "" && !strings.HasPrefix(arg, "-") {
 			cfg.trendsRepo = arg
 			continue
+		}
+
+		// If the arg looks like a local file (not a URL, not a flag), check if
+		// it exists on disk — if so, treat it as a trace file input.
+		if !strings.HasPrefix(arg, "http") && !strings.HasPrefix(arg, "-") {
+			if _, err := os.Stat(arg); err == nil {
+				cfg.traceFiles = append(cfg.traceFiles, arg)
+				continue
+			}
 		}
 
 		cfg.urls = append(cfg.urls, arg)
@@ -353,7 +367,7 @@ func main() {
 	}
 
 	if len(args) == 0 && len(cfg.traceFiles) == 0 && !hasTraceBackend {
-		printErrorMsg("No GitHub URLs or trace files provided.\n\n  Usage: gha-analyzer <github_url> [flags]\n         gha-analyzer --trace=<file.json> [flags]\n         gha-analyzer --tempo=<url> --trace-id=<id> [flags]\n\n  Run 'gha-analyzer --help' for more information.")
+		printErrorMsg("No GitHub URLs or trace files provided.\n\n  Usage: gha-analyzer <github_url> [flags]\n         gha-analyzer <trace_file.json> [flags]\n         gha-analyzer --tempo=<url> --trace-id=<id> [flags]\n\n  Run 'gha-analyzer --help' for more information.")
 		os.Exit(1)
 	}
 
@@ -478,7 +492,8 @@ func main() {
 		progress.Start()
 
 		ingestor := polling.NewPollingIngestor(client, args, progress, analyzer.AnalyzeOptions{
-			Window: cfg.window,
+			Window:      cfg.window,
+			NoArtifacts: cfg.noArtifacts,
 		})
 		var err error
 		results, globalEarliest, globalLatest, ghaSpans, err = ingestor.Ingest(ctx)
@@ -672,6 +687,7 @@ func printUsage() {
 	fmt.Println("GitHub Actions Analyzer")
 	fmt.Println("\nUsage:")
 	fmt.Println("  gha-analyzer <github_url1> [github_url2...] [token] [flags]")
+	fmt.Println("  gha-analyzer <trace_file.json> [flags]")
 	fmt.Println("  gha-analyzer trends <owner/repo> [flags]")
 	fmt.Println("\nFlags:")
 	fmt.Println("  --tui                     Force interactive TUI mode (default when terminal is available)")
@@ -688,6 +704,7 @@ func printUsage() {
 	fmt.Println("  --tempo=<baseURL>         Fetch traces from Grafana Tempo (e.g., http://localhost:3200)")
 	fmt.Println("  --jaeger=<baseURL>        Fetch traces from Jaeger v2 (e.g., http://localhost:16686)")
 	fmt.Println("  --trace-id=<id>           Trace ID to fetch from Tempo/Jaeger (can be repeated)")
+	fmt.Println("  --no-artifacts            Skip downloading and ingesting trace artifacts from workflow runs")
 	fmt.Println("  --clear-cache             Clear the HTTP cache (can be combined with other flags)")
 	fmt.Println("  help, --help, -h          Show this help message")
 	fmt.Println("\nTrends Mode Flags:")
@@ -709,7 +726,8 @@ func printUsage() {
 	fmt.Println("  gha-analyzer trends owner/repo")
 	fmt.Println("  gha-analyzer trends owner/repo --days=7 --format=json")
 	fmt.Println("  gha-analyzer trends owner/repo --branch=main --workflow=post-merge.yaml")
-	fmt.Println("  gha-analyzer --trace=spans.json")
+	fmt.Println("  gha-analyzer trace.json                      # auto-detects OTel or Chrome Tracing format")
+	fmt.Println("  gha-analyzer chrome-profile.json spans.json   # multiple trace files as args")
 	fmt.Println("  gha-analyzer --trace=spans.json https://github.com/owner/repo/pull/123")
 	fmt.Println("  gha-analyzer --tempo=http://localhost:3200 --trace-id=abc123def456")
 	fmt.Println("  gha-analyzer --jaeger=http://localhost:16686 --trace-id=abc123def456")

--- a/pkg/analyzer/BUILD.bazel
+++ b/pkg/analyzer/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "analyzer",
     srcs = [
         "analyzer.go",
+        "artifacts.go",
         "data_provider.go",
         "metrics.go",
         "otel_analyzer.go",
@@ -18,6 +19,7 @@ go_library(
     deps = [
         "//pkg/enrichment",
         "//pkg/githubapi",
+        "//pkg/ingest/otlpfile",
         "//pkg/utils",
         "@com_github_cockroachdb_errors//:errors",
         "@io_opentelemetry_go_otel//attribute",

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -54,7 +54,8 @@ func (e URLError) Error() string {
 }
 
 type AnalyzeOptions struct {
-	Window time.Duration
+	Window      time.Duration
+	NoArtifacts bool
 }
 
 func AnalyzeURLs(ctx context.Context, urls []string, client githubapi.GitHubProvider, reporter ProgressReporter, opts AnalyzeOptions) ([]URLResult, []TraceEvent, int64, int64, []sdktrace.ReadOnlySpan, []URLError) {
@@ -102,7 +103,7 @@ func AnalyzeURLs(ctx context.Context, urls []string, client githubapi.GitHubProv
 			}
 		}
 
-		result, err := buildURLResult(ctx, rawData.Parsed, urlIndex, rawData.HeadSHA, rawData.BranchName, rawData.DisplayName, rawData.DisplayURL, rawData.ReviewEvents, rawData.MergedAtMs, rawData.CommitTimeMs, rawData.CommitPushedAtMs, rawData.AllCommitRunsCount, rawData.AllCommitRunsComputeMs, rawData.Runs, rawData.RequiredContexts, client, reporter, urlEarliestTime, builder)
+		result, err := buildURLResult(ctx, rawData.Parsed, urlIndex, rawData.HeadSHA, rawData.BranchName, rawData.DisplayName, rawData.DisplayURL, rawData.ReviewEvents, rawData.MergedAtMs, rawData.CommitTimeMs, rawData.CommitPushedAtMs, rawData.AllCommitRunsCount, rawData.AllCommitRunsComputeMs, rawData.Runs, rawData.RequiredContexts, client, reporter, urlEarliestTime, builder, opts)
 		if err != nil {
 			urlErrors = append(urlErrors, URLError{URL: githubURL, Err: err})
 			continue
@@ -152,7 +153,7 @@ func AnalyzeURLs(ctx context.Context, urls []string, client githubapi.GitHubProv
 	return urlResults, allTraceEvents, globalEarliestTime, globalLatestTime, builder.Spans(), urlErrors
 }
 
-func buildURLResult(ctx context.Context, parsed utils.ParsedGitHubURL, urlIndex int, headSHA, branchName, displayName, displayURL string, reviewEvents []ReviewEvent, mergedAtMs, commitTimeMs, commitPushedAtMs *int64, allCommitRunsCount int, allCommitRunsComputeMs int64, runs []githubapi.WorkflowRun, requiredContexts []string, client githubapi.GitHubProvider, reporter ProgressReporter, urlEarliestTime int64, builder *SpanBuilder) (*URLResult, error) {
+func buildURLResult(ctx context.Context, parsed utils.ParsedGitHubURL, urlIndex int, headSHA, branchName, displayName, displayURL string, reviewEvents []ReviewEvent, mergedAtMs, commitTimeMs, commitPushedAtMs *int64, allCommitRunsCount int, allCommitRunsComputeMs int64, runs []githubapi.WorkflowRun, requiredContexts []string, client githubapi.GitHubProvider, reporter ProgressReporter, urlEarliestTime int64, builder *SpanBuilder, opts AnalyzeOptions) (*URLResult, error) {
 	if reporter != nil {
 		reporter.SetURLRuns(len(runs))
 		reporter.SetPhase("Processing workflow runs")
@@ -189,7 +190,7 @@ func buildURLResult(ctx context.Context, parsed utils.ParsedGitHubURL, urlIndex 
 			defer wg.Done()
 			for job := range jobsCh {
 				processID := (urlIndex+1)*1000 + job.index + 1
-				runMetrics, runTrace, runStarts, runEnds, err := processWorkflowRun(ctx, job.run, job.index, processID, urlEarliestTime, parsed.Owner, parsed.Repo, parsed.Identifier, urlIndex, displayURL, parsed.Type, requiredContexts, client, reporter, builder)
+				runMetrics, runTrace, runStarts, runEnds, err := processWorkflowRun(ctx, job.run, job.index, processID, urlEarliestTime, parsed.Owner, parsed.Repo, parsed.Identifier, urlIndex, displayURL, parsed.Type, requiredContexts, client, reporter, builder, opts)
 				resultsCh <- runResult{
 					metrics:     runMetrics,
 					traceEvents: runTrace,
@@ -250,7 +251,7 @@ func buildURLResult(ctx context.Context, parsed utils.ParsedGitHubURL, urlIndex 
 	return &result, nil
 }
 
-func processWorkflowRun(ctx context.Context, run githubapi.WorkflowRun, runIndex, processID int, earliestTime int64, owner, repo, identifier string, urlIndex int, displayURL, sourceType string, requiredContexts []string, client githubapi.GitHubProvider, reporter ProgressReporter, builder *SpanBuilder) (Metrics, []TraceEvent, []JobEvent, []JobEvent, error) {
+func processWorkflowRun(ctx context.Context, run githubapi.WorkflowRun, runIndex, processID int, earliestTime int64, owner, repo, identifier string, urlIndex int, displayURL, sourceType string, requiredContexts []string, client githubapi.GitHubProvider, reporter ProgressReporter, builder *SpanBuilder, opts AnalyzeOptions) (Metrics, []TraceEvent, []JobEvent, []JobEvent, error) {
 	metrics := InitializeMetrics()
 	traceEvents := []TraceEvent{}
 	jobStartTimes := []JobEvent{}
@@ -261,6 +262,9 @@ func processWorkflowRun(ctx context.Context, run githubapi.WorkflowRun, runIndex
 		metrics.SuccessfulRuns = 1
 	} else {
 		metrics.FailedRuns = 1
+	}
+	if run.RunAttempt > 1 {
+		metrics.RetriedRuns = 1
 	}
 
 	baseURL := fmt.Sprintf("https://api.github.com/repos/%s/%s", run.Repository.Owner.Login, run.Repository.Name)
@@ -388,35 +392,75 @@ func processWorkflowRun(ctx context.Context, run githubapi.WorkflowRun, runIndex
 			"source_type":       sourceType,
 			"source_identifier": identifier,
 			"url_index":         urlIndex + 1,
+			"run_attempt":       run.RunAttempt,
 		},
 	})
 
+	// Fetch annotations for failed check runs (best-effort)
+	jobAnnotations := map[string][]githubapi.Annotation{}
+	checkRuns, err := client.FetchCheckRunsForCommit(ctx, run.Repository.Owner.Login, run.Repository.Name, run.HeadSHA)
+	if err == nil {
+		for _, cr := range checkRuns {
+			if cr.Conclusion == "failure" {
+				annotations, err := client.FetchAnnotations(ctx, run.Repository.Owner.Login, run.Repository.Name, cr.ID)
+				if err == nil && len(annotations) > 0 {
+					jobAnnotations[cr.Name] = append(jobAnnotations[cr.Name], annotations...)
+				}
+			}
+		}
+	}
+
 	for jobIndex, job := range jobs {
 		jobThreadID := jobIndex + 10
-		processJob(job, jobIndex, run, jobThreadID, processID, earliestTime, &metrics, &traceEvents, &jobStartTimes, &jobEndTimes, prURL, urlIndex, displayURL, sourceType, identifier, requiredContexts, builder, tid, wfSC)
+		processJob(job, jobIndex, run, jobThreadID, processID, earliestTime, &metrics, &traceEvents, &jobStartTimes, &jobEndTimes, prURL, urlIndex, displayURL, sourceType, identifier, requiredContexts, builder, tid, wfSC, jobAnnotations[job.Name])
+	}
+
+	// Fetch billable timing (best-effort, don't fail on error)
+	if run.Status == "completed" {
+		timing, err := client.FetchRunTiming(ctx, run.Repository.Owner.Login, run.Repository.Name, run.ID)
+		if err == nil && timing != nil {
+			for osName, billable := range timing.Billable {
+				if billable.TotalMs > 0 {
+					metrics.BillableMs[osName] += billable.TotalMs
+				}
+			}
+		}
+	}
+
+	// Ingest trace artifacts (best-effort)
+	if !opts.NoArtifacts {
+		_ = IngestTraceArtifacts(ctx, client, run.Repository.Owner.Login, run.Repository.Name, run.ID, builder)
 	}
 
 	// Build workflow span stub (after processing jobs so runEnd may be adjusted)
+	wfAttrs := []attribute.KeyValue{
+		attribute.String("type", "workflow"),
+		attribute.Int64("github.run_id", run.ID),
+		attribute.String("github.status", run.Status),
+		attribute.String("github.conclusion", run.Conclusion),
+		attribute.String("github.repo", fmt.Sprintf("%s/%s", owner, repo)),
+		attribute.String("github.url", workflowURL),
+		attribute.Int("github.url_index", urlIndex),
+	}
+	if run.RunAttempt > 1 {
+		wfAttrs = append(wfAttrs, attribute.Int64("github.run_attempt", run.RunAttempt))
+	}
+	// Add billable timing attributes
+	for osName, ms := range metrics.BillableMs {
+		wfAttrs = append(wfAttrs, attribute.Int64(fmt.Sprintf("billable.%s_ms", strings.ToLower(osName)), ms))
+	}
 	builder.Add(tracetest.SpanStub{
 		Name:        defaultRunName(run),
 		SpanContext: wfSC,
 		StartTime:   runStart,
 		EndTime:     runEnd,
-		Attributes: []attribute.KeyValue{
-			attribute.String("type", "workflow"),
-			attribute.Int64("github.run_id", run.ID),
-			attribute.String("github.status", run.Status),
-			attribute.String("github.conclusion", run.Conclusion),
-			attribute.String("github.repo", fmt.Sprintf("%s/%s", owner, repo)),
-			attribute.String("github.url", workflowURL),
-			attribute.Int("github.url_index", urlIndex),
-		},
+		Attributes:  wfAttrs,
 	})
 
 	return metrics, traceEvents, jobStartTimes, jobEndTimes, nil
 }
 
-func processJob(job githubapi.Job, jobIndex int, run githubapi.WorkflowRun, jobThreadID, processID int, earliestTime int64, metrics *Metrics, traceEvents *[]TraceEvent, jobStartTimes, jobEndTimes *[]JobEvent, prURL string, urlIndex int, displayURL, sourceType, identifier string, requiredContexts []string, builder *SpanBuilder, traceID trace.TraceID, parentSC trace.SpanContext) {
+func processJob(job githubapi.Job, jobIndex int, run githubapi.WorkflowRun, jobThreadID, processID int, earliestTime int64, metrics *Metrics, traceEvents *[]TraceEvent, jobStartTimes, jobEndTimes *[]JobEvent, prURL string, urlIndex int, displayURL, sourceType, identifier string, requiredContexts []string, builder *SpanBuilder, traceID trace.TraceID, parentSC trace.SpanContext, annotations []githubapi.Annotation) {
 	if job.StartedAt == "" {
 		return
 	}
@@ -487,7 +531,18 @@ func processJob(job githubapi.Job, jobIndex int, run githubapi.WorkflowRun, jobT
 		metrics.ShortestJob = JobDuration{Name: job.Name, Duration: float64(jobDuration)}
 	}
 	if job.RunnerName != "" {
-		metrics.RunnerTypes[job.RunnerName] = struct{}{}
+		metrics.RunnerJobCounts[job.RunnerName]++
+		metrics.RunnerDurations[job.RunnerName] += float64(jobDuration)
+	}
+
+	// Queue time: CreatedAt → StartedAt (only for jobs that actually ran)
+	if job.CreatedAt != "" && job.Conclusion != "skipped" && job.Conclusion != "cancelled" {
+		if createdAt, ok := utils.ParseTime(job.CreatedAt); ok {
+			queueMs := float64(absoluteJobStart.UnixMilli() - createdAt.UnixMilli())
+			if queueMs > 0 {
+				metrics.QueueTimes = append(metrics.QueueTimes, queueMs)
+			}
+		}
 	}
 
 	*jobStartTimes = append(*jobStartTimes, JobEvent{Ts: jobStartTs, Type: "start"})
@@ -517,6 +572,51 @@ func processJob(job githubapi.Job, jobIndex int, run githubapi.WorkflowRun, jobT
 		jobLabel = fmt.Sprintf("%s%s ❌", job.Name, requiredSuffix)
 	}
 	AddThreadMetadata(traceEvents, processID, jobThreadID, jobLabel, intPtr(jobIndex+10))
+
+	// Emit queued span (CreatedAt → StartedAt) — only for jobs that actually ran
+	if job.CreatedAt != "" && job.Conclusion != "skipped" && job.Conclusion != "cancelled" {
+		if createdAt, ok := utils.ParseTime(job.CreatedAt); ok {
+			queueStartTs := createdAt.UnixMilli()
+			if queueStartTs < jobStartTs {
+				normalizedQueueStart := (queueStartTs - earliestTime) * 1000
+				normalizedQueueEnd := (jobStartTs - earliestTime) * 1000
+				queueDurMs := jobStartTs - queueStartTs
+				*traceEvents = append(*traceEvents, TraceEvent{
+					Name: fmt.Sprintf("⏳ Queued [%d]", urlIndex+1),
+					Ph:   "X",
+					Ts:   normalizedQueueStart,
+					Dur:  normalizedQueueEnd - normalizedQueueStart,
+					Pid:  processID,
+					Tid:  jobThreadID,
+					Cat:  "queued",
+					Args: map[string]interface{}{
+						"type":            "queued",
+						"github.job_name": job.Name,
+						"queue_time_ms":   queueDurMs,
+					},
+				})
+
+				// Emit OTel span for queued period (child of job, not workflow)
+				queueSID := githubapi.NewSpanIDFromString(fmt.Sprintf("queued-%d", job.ID))
+				builder.Add(tracetest.SpanStub{
+					Name: "⏳ Queued",
+					SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+						TraceID:    traceID,
+						SpanID:     queueSID,
+						TraceFlags: trace.FlagsSampled,
+					}),
+					Parent:    jobSC,
+					StartTime: createdAt,
+					EndTime:   absoluteJobStart,
+					Attributes: []attribute.KeyValue{
+						attribute.String("type", "queued"),
+						attribute.String("github.job_name", job.Name),
+						attribute.Int64("queue_time_ms", queueDurMs),
+					},
+				})
+			}
+		}
+	}
 
 	normalizedJobStart := (jobStartTs - earliestTime) * 1000
 	normalizedJobEnd := (jobEndTs - earliestTime) * 1000
@@ -552,21 +652,52 @@ func processJob(job githubapi.Job, jobIndex int, run githubapi.WorkflowRun, jobT
 		processStep(step, job, run, jobThreadID, processID, earliestTime, jobEndTs, metrics, traceEvents, prURL, urlIndex, displayURL, sourceType, identifier, builder, traceID, jobSC)
 	}
 
+	jobAttrs := []attribute.KeyValue{
+		attribute.String("type", "job"),
+		attribute.Int64("github.job_id", job.ID),
+		attribute.String("github.status", job.Status),
+		attribute.String("github.conclusion", job.Conclusion),
+		attribute.String("github.runner_name", job.RunnerName),
+		attribute.String("github.url", jobURL),
+		attribute.Bool("is_required", isRequired),
+	}
+	if job.RunnerName != "" {
+		jobAttrs = append(jobAttrs, attribute.String("k8s.pod.name", job.RunnerName))
+	}
+	// Add queue_time_ms if we have CreatedAt
+	if job.CreatedAt != "" {
+		if createdAt, ok := utils.ParseTime(job.CreatedAt); ok {
+			queueMs := absoluteJobStart.UnixMilli() - createdAt.UnixMilli()
+			if queueMs > 0 {
+				jobAttrs = append(jobAttrs, attribute.Int64("queue_time_ms", queueMs))
+			}
+		}
+	}
+	// Build annotation events for the job span
+	var spanEvents []sdktrace.Event
+	for _, ann := range annotations {
+		title := ann.Title
+		if title == "" {
+			title = ann.Message
+		}
+		spanEvents = append(spanEvents, sdktrace.Event{
+			Name: title,
+			Attributes: []attribute.KeyValue{
+				attribute.String("annotation.path", ann.Path),
+				attribute.Int("annotation.line", ann.StartLine),
+				attribute.String("annotation.level", ann.Level),
+				attribute.String("annotation.message", ann.Message),
+			},
+		})
+	}
 	builder.Add(tracetest.SpanStub{
 		Name:        job.Name + requiredSuffix,
 		SpanContext: jobSC,
 		Parent:      parentSC,
 		StartTime:   jobStart,
 		EndTime:     jobEnd,
-		Attributes: []attribute.KeyValue{
-			attribute.String("type", "job"),
-			attribute.Int64("github.job_id", job.ID),
-			attribute.String("github.status", job.Status),
-			attribute.String("github.conclusion", job.Conclusion),
-			attribute.String("github.runner_name", job.RunnerName),
-			attribute.String("github.url", jobURL),
-			attribute.Bool("is_required", isRequired),
-		},
+		Attributes:  jobAttrs,
+		Events:      spanEvents,
 	})
 }
 
@@ -832,8 +963,16 @@ func mergeMetrics(target *Metrics, source Metrics) {
 	target.JobTimeline = append(target.JobTimeline, source.JobTimeline...)
 	target.PendingJobs = append(target.PendingJobs, source.PendingJobs...)
 
-	for runner := range source.RunnerTypes {
-		target.RunnerTypes[runner] = struct{}{}
+	for runner, count := range source.RunnerJobCounts {
+		target.RunnerJobCounts[runner] += count
+	}
+	for runner, dur := range source.RunnerDurations {
+		target.RunnerDurations[runner] += dur
+	}
+	target.QueueTimes = append(target.QueueTimes, source.QueueTimes...)
+	target.RetriedRuns += source.RetriedRuns
+	for os, ms := range source.BillableMs {
+		target.BillableMs[os] += ms
 	}
 
 	if source.LongestJob.Duration > target.LongestJob.Duration {

--- a/pkg/analyzer/artifacts.go
+++ b/pkg/analyzer/artifacts.go
@@ -1,0 +1,89 @@
+package analyzer
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/stefanpenner/gha-analyzer/pkg/githubapi"
+	"github.com/stefanpenner/gha-analyzer/pkg/ingest/otlpfile"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// IngestTraceArtifacts downloads artifacts matching "gha-trace.*" from a workflow run,
+// parses them as OTLP JSON or Chrome trace format, and adds spans to the builder.
+func IngestTraceArtifacts(ctx context.Context, client githubapi.GitHubProvider, owner, repo string, runID int64, builder *SpanBuilder) error {
+	artifacts, err := client.ListArtifacts(ctx, owner, repo, runID)
+	if err != nil {
+		return nil // best-effort
+	}
+
+	for _, artifact := range artifacts {
+		if artifact.Expired {
+			continue
+		}
+		if !strings.HasPrefix(artifact.Name, "gha-trace") {
+			continue
+		}
+
+		data, err := client.DownloadArtifact(ctx, artifact.ArchiveDownloadURL)
+		if err != nil {
+			continue // best-effort
+		}
+
+		spans, err := extractSpansFromZip(data)
+		if err != nil {
+			continue // best-effort
+		}
+
+		// Convert ReadOnlySpans to SpanStubs and add to builder
+		for _, s := range spans {
+			builder.Add(tracetest.SpanStub{
+				Name:        s.Name(),
+				SpanContext: s.SpanContext(),
+				Parent:      s.Parent(),
+				SpanKind:    s.SpanKind(),
+				StartTime:   s.StartTime(),
+				EndTime:     s.EndTime(),
+				Attributes:  s.Attributes(),
+				Events:      s.Events(),
+				Links:       s.Links(),
+				Status:      s.Status(),
+			})
+		}
+	}
+
+	return nil
+}
+
+// extractSpansFromZip unzips artifact data and parses any JSON files as OTLP or Chrome traces.
+func extractSpansFromZip(data []byte) ([]sdktrace.ReadOnlySpan, error) {
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open zip: %w", err)
+	}
+
+	var allSpans []sdktrace.ReadOnlySpan
+	for _, f := range reader.File {
+		if !strings.HasSuffix(f.Name, ".json") {
+			continue
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			continue
+		}
+
+		spans, err := otlpfile.Parse(rc)
+		rc.Close()
+		if err != nil || len(spans) == 0 {
+			continue
+		}
+		allSpans = append(allSpans, spans...)
+	}
+
+	return allSpans, nil
+}

--- a/pkg/analyzer/metrics.go
+++ b/pkg/analyzer/metrics.go
@@ -11,14 +11,17 @@ import (
 
 func InitializeMetrics() Metrics {
 	return Metrics{
-		JobDurations:  []float64{},
-		JobNames:      []string{},
-		JobURLs:       []string{},
-		StepDurations: []StepDuration{},
-		RunnerTypes:   map[string]struct{}{},
-		JobTimeline:   []TimelineJob{},
-		LongestJob:    JobDuration{Name: "", Duration: 0},
-		ShortestJob:   JobDuration{Name: "", Duration: math.Inf(1)},
+		JobDurations:    []float64{},
+		JobNames:        []string{},
+		JobURLs:         []string{},
+		StepDurations:   []StepDuration{},
+		RunnerJobCounts: map[string]int{},
+		RunnerDurations: map[string]float64{},
+		QueueTimes:      []float64{},
+		BillableMs:      map[string]int64{},
+		JobTimeline:     []TimelineJob{},
+		LongestJob:      JobDuration{Name: "", Duration: 0},
+		ShortestJob:     JobDuration{Name: "", Duration: math.Inf(1)},
 	}
 }
 
@@ -104,6 +107,26 @@ func CalculateFinalMetrics(metrics Metrics, totalRuns int, jobStartTimes, jobEnd
 		jobSuccessRate = formatPercent(float64(metrics.TotalJobs-metrics.FailedJobs) / float64(metrics.TotalJobs) * 100)
 	}
 
+	// Queue time stats
+	avgQueueTime := 0.0
+	maxQueueTime := 0.0
+	if len(metrics.QueueTimes) > 0 {
+		sum := 0.0
+		for _, qt := range metrics.QueueTimes {
+			sum += qt
+			if qt > maxQueueTime {
+				maxQueueTime = qt
+			}
+		}
+		avgQueueTime = sum / float64(len(metrics.QueueTimes))
+	}
+
+	// Retry rate
+	retryRate := "0"
+	if metrics.TotalRuns > 0 {
+		retryRate = formatPercent(float64(metrics.RetriedRuns) / float64(metrics.TotalRuns) * 100)
+	}
+
 	return FinalMetrics{
 		Metrics:         metrics,
 		AvgJobDuration:  avgJob,
@@ -111,6 +134,9 @@ func CalculateFinalMetrics(metrics Metrics, totalRuns int, jobStartTimes, jobEnd
 		SuccessRate:     successRate,
 		JobSuccessRate:  jobSuccessRate,
 		MaxConcurrency:  CalculateMaxConcurrency(jobStartTimes, jobEndTimes),
+		AvgQueueTime:    avgQueueTime,
+		MaxQueueTime:    maxQueueTime,
+		RetryRate:       retryRate,
 	}
 }
 

--- a/pkg/analyzer/otel_test.go
+++ b/pkg/analyzer/otel_test.go
@@ -68,6 +68,34 @@ func (m *mockGitHubProvider) FetchRecentWorkflowRuns(ctx context.Context, owner,
 	return args.Get(0).([]githubapi.WorkflowRun), args.Error(1)
 }
 
+func (m *mockGitHubProvider) FetchRunTiming(ctx context.Context, owner, repo string, runID int64) (*githubapi.RunTiming, error) {
+	args := m.Called(ctx, owner, repo, runID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*githubapi.RunTiming), args.Error(1)
+}
+
+func (m *mockGitHubProvider) FetchCheckRunsForCommit(ctx context.Context, owner, repo, sha string) ([]githubapi.CheckRun, error) {
+	args := m.Called(ctx, owner, repo, sha)
+	return args.Get(0).([]githubapi.CheckRun), args.Error(1)
+}
+
+func (m *mockGitHubProvider) FetchAnnotations(ctx context.Context, owner, repo string, checkRunID int64) ([]githubapi.Annotation, error) {
+	args := m.Called(ctx, owner, repo, checkRunID)
+	return args.Get(0).([]githubapi.Annotation), args.Error(1)
+}
+
+func (m *mockGitHubProvider) ListArtifacts(ctx context.Context, owner, repo string, runID int64) ([]githubapi.Artifact, error) {
+	args := m.Called(ctx, owner, repo, runID)
+	return args.Get(0).([]githubapi.Artifact), args.Error(1)
+}
+
+func (m *mockGitHubProvider) DownloadArtifact(ctx context.Context, url string) ([]byte, error) {
+	args := m.Called(ctx, url)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
 func TestSpanBuilderGeneration(t *testing.T) {
 	mockClient := new(mockGitHubProvider)
 
@@ -96,7 +124,7 @@ func TestSpanBuilderGeneration(t *testing.T) {
 			ReviewEvents: reviewEvents,
 		}, 0)
 
-		_, err := buildURLResult(context.Background(), parsed, 0, "sha", "main", "PR 1", "url", reviewEvents, nil, nil, nil, 0, 0, nil, nil, mockClient, nil, 0, builder)
+		_, err := buildURLResult(context.Background(), parsed, 0, "sha", "main", "PR 1", "url", reviewEvents, nil, nil, nil, 0, 0, nil, nil, mockClient, nil, 0, builder, AnalyzeOptions{})
 		assert.NoError(t, err)
 
 		spans := builder.Spans()
@@ -135,7 +163,7 @@ func TestSpanBuilderGeneration(t *testing.T) {
 			CommitTimeMs: &commitTimeMs,
 		}, 0)
 
-		_, err := buildURLResult(context.Background(), parsed, 0, "sha123", "main", "Commit sha123", "url", nil, nil, &commitTimeMs, nil, 0, 0, nil, nil, mockClient, nil, 0, builder)
+		_, err := buildURLResult(context.Background(), parsed, 0, "sha123", "main", "Commit sha123", "url", nil, nil, &commitTimeMs, nil, 0, 0, nil, nil, mockClient, nil, 0, builder, AnalyzeOptions{})
 		assert.NoError(t, err)
 
 		spans := builder.Spans()

--- a/pkg/analyzer/types.go
+++ b/pkg/analyzer/types.go
@@ -7,23 +7,27 @@ import (
 )
 
 type Metrics struct {
-	TotalRuns      int
-	SuccessfulRuns int
-	FailedRuns     int
-	TotalJobs      int
-	FailedJobs     int
-	TotalSteps     int
-	FailedSteps    int
-	JobDurations   []float64
-	JobNames       []string
-	JobURLs        []string
-	StepDurations  []StepDuration
-	RunnerTypes    map[string]struct{}
-	TotalDuration  float64
-	LongestJob     JobDuration
-	ShortestJob    JobDuration
-	JobTimeline    []TimelineJob
-	PendingJobs    []PendingJob
+	TotalRuns       int
+	SuccessfulRuns  int
+	FailedRuns      int
+	RetriedRuns     int
+	TotalJobs       int
+	FailedJobs      int
+	TotalSteps      int
+	FailedSteps     int
+	JobDurations    []float64
+	JobNames        []string
+	JobURLs         []string
+	StepDurations   []StepDuration
+	RunnerJobCounts map[string]int
+	RunnerDurations map[string]float64
+	QueueTimes      []float64
+	BillableMs      map[string]int64
+	TotalDuration   float64
+	LongestJob      JobDuration
+	ShortestJob     JobDuration
+	JobTimeline     []TimelineJob
+	PendingJobs     []PendingJob
 }
 
 type StepDuration struct {
@@ -63,6 +67,9 @@ type FinalMetrics struct {
 	SuccessRate     string
 	JobSuccessRate  string
 	MaxConcurrency  int
+	AvgQueueTime    float64
+	MaxQueueTime    float64
+	RetryRate       string
 }
 
 type JobEvent struct {

--- a/pkg/githubapi/client.go
+++ b/pkg/githubapi/client.go
@@ -871,3 +871,138 @@ func (c *Client) FetchBranchProtection(ctx context.Context, owner, repo, branch 
 
 	return &BranchProtection{RequiredStatusChecks: &protection}, nil
 }
+
+// RunTiming represents the billing timing for a workflow run.
+type RunTiming struct {
+	Billable map[string]BillableOS `json:"billable"`
+}
+
+// BillableOS represents billable time for an OS.
+type BillableOS struct {
+	TotalMs int64 `json:"total_ms"`
+}
+
+// CheckRun represents a GitHub check run.
+type CheckRun struct {
+	ID         int64  `json:"id"`
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+// Annotation represents a check run annotation.
+type Annotation struct {
+	Path      string `json:"path"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+	Level     string `json:"annotation_level"`
+	Message   string `json:"message"`
+	Title     string `json:"title"`
+}
+
+// Artifact represents a GitHub Actions artifact.
+type Artifact struct {
+	ID                 int64  `json:"id"`
+	Name               string `json:"name"`
+	SizeInBytes        int64  `json:"size_in_bytes"`
+	ArchiveDownloadURL string `json:"archive_download_url"`
+	Expired            bool   `json:"expired"`
+}
+
+func (c *Client) FetchRunTiming(ctx context.Context, owner, repo string, runID int64) (*RunTiming, error) {
+	ctx, span := getTracer().Start(ctx, "FetchRunTiming", trace.WithAttributes(
+		attribute.String("github.owner", owner),
+		attribute.String("github.repo", repo),
+		attribute.Int64("github.run_id", runID),
+	))
+	defer span.End()
+
+	endpoint := fmt.Sprintf("https://api.github.com/repos/%s/%s/actions/runs/%d/timing", owner, repo, runID)
+	resp, err := fetchWithAuth(ctx, c, endpoint, "")
+	if err != nil {
+		return nil, err
+	}
+	var timing RunTiming
+	if err := decodeJSON(resp, &timing); err != nil {
+		return nil, err
+	}
+	return &timing, nil
+}
+
+func (c *Client) FetchCheckRunsForCommit(ctx context.Context, owner, repo, sha string) ([]CheckRun, error) {
+	ctx, span := getTracer().Start(ctx, "FetchCheckRunsForCommit", trace.WithAttributes(
+		attribute.String("github.owner", owner),
+		attribute.String("github.repo", repo),
+		attribute.String("github.sha", sha),
+	))
+	defer span.End()
+
+	endpoint := fmt.Sprintf("https://api.github.com/repos/%s/%s/commits/%s/check-runs?per_page=100", owner, repo, sha)
+	resp, err := fetchWithAuth(ctx, c, endpoint, "")
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		CheckRuns []CheckRun `json:"check_runs"`
+	}
+	if err := decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+	return result.CheckRuns, nil
+}
+
+func (c *Client) FetchAnnotations(ctx context.Context, owner, repo string, checkRunID int64) ([]Annotation, error) {
+	ctx, span := getTracer().Start(ctx, "FetchAnnotations", trace.WithAttributes(
+		attribute.String("github.owner", owner),
+		attribute.String("github.repo", repo),
+		attribute.Int64("github.check_run_id", checkRunID),
+	))
+	defer span.End()
+
+	endpoint := fmt.Sprintf("https://api.github.com/repos/%s/%s/check-runs/%d/annotations?per_page=100", owner, repo, checkRunID)
+	resp, err := fetchWithAuth(ctx, c, endpoint, "")
+	if err != nil {
+		return nil, err
+	}
+	var annotations []Annotation
+	if err := decodeJSON(resp, &annotations); err != nil {
+		return nil, err
+	}
+	return annotations, nil
+}
+
+func (c *Client) ListArtifacts(ctx context.Context, owner, repo string, runID int64) ([]Artifact, error) {
+	ctx, span := getTracer().Start(ctx, "ListArtifacts", trace.WithAttributes(
+		attribute.String("github.owner", owner),
+		attribute.String("github.repo", repo),
+		attribute.Int64("github.run_id", runID),
+	))
+	defer span.End()
+
+	endpoint := fmt.Sprintf("https://api.github.com/repos/%s/%s/actions/runs/%d/artifacts?per_page=100", owner, repo, runID)
+	resp, err := fetchWithAuth(ctx, c, endpoint, "")
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		Artifacts []Artifact `json:"artifacts"`
+	}
+	if err := decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+	return result.Artifacts, nil
+}
+
+func (c *Client) DownloadArtifact(ctx context.Context, downloadURL string) ([]byte, error) {
+	ctx, span := getTracer().Start(ctx, "DownloadArtifact", trace.WithAttributes(
+		attribute.String("github.url", downloadURL),
+	))
+	defer span.End()
+
+	resp, err := fetchWithAuth(ctx, c, downloadURL, "application/vnd.github.v3+json")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}

--- a/pkg/githubapi/provider.go
+++ b/pkg/githubapi/provider.go
@@ -16,4 +16,9 @@ type GitHubProvider interface {
 	FetchPRComments(ctx context.Context, owner, repo, prNumber string) ([]Review, error)
 	FetchJobsPaginated(ctx context.Context, urlValue string) ([]Job, error)
 	FetchBranchProtection(ctx context.Context, owner, repo, branch string) (*BranchProtection, error)
+	FetchRunTiming(ctx context.Context, owner, repo string, runID int64) (*RunTiming, error)
+	FetchCheckRunsForCommit(ctx context.Context, owner, repo, sha string) ([]CheckRun, error)
+	FetchAnnotations(ctx context.Context, owner, repo string, checkRunID int64) ([]Annotation, error)
+	ListArtifacts(ctx context.Context, owner, repo string, runID int64) ([]Artifact, error)
+	DownloadArtifact(ctx context.Context, url string) ([]byte, error)
 }

--- a/pkg/ingest/otlpfile/BUILD.bazel
+++ b/pkg/ingest/otlpfile/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "otlpfile",
     srcs = [
+        "chrome.go",
         "otlpfile.go",
         "proto.go",
         "span.go",

--- a/pkg/ingest/otlpfile/chrome.go
+++ b/pkg/ingest/otlpfile/chrome.go
@@ -1,0 +1,199 @@
+package otlpfile
+
+// Chrome Tracing format parser.
+//
+// Supports the Trace Event Format used by Chrome DevTools, Perfetto,
+// and other profiling tools. Events are converted to OTel ReadOnlySpans.
+//
+// Supported event phases:
+//   - "X" (complete): has ts + dur
+//   - "B"/"E" (begin/end): paired by name+pid+tid
+//   - "i"/"I" (instant): zero-duration span
+//
+// Reference: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"sort"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// chromeTrace is the top-level Chrome Tracing JSON structure.
+type chromeTrace struct {
+	TraceEvents []chromeEvent `json:"traceEvents"`
+}
+
+// chromeEvent represents a single event in Chrome Tracing format.
+type chromeEvent struct {
+	Name string                 `json:"name"`
+	Ph   string                 `json:"ph"`
+	Ts   float64                `json:"ts"`  // microseconds
+	Dur  float64                `json:"dur"` // microseconds (for "X" events)
+	Pid  json.Number            `json:"pid"`
+	Tid  json.Number            `json:"tid"`
+	Cat  string                 `json:"cat,omitempty"`
+	Args map[string]any `json:"args,omitempty"`
+	ID   string                 `json:"id,omitempty"`
+}
+
+// ParseChrome reads Chrome Tracing JSON and returns ReadOnlySpans.
+// Accepts either {"traceEvents": [...]} or a bare [...] array.
+func ParseChrome(r io.Reader) ([]sdktrace.ReadOnlySpan, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading chrome trace: %w", err)
+	}
+
+	var events []chromeEvent
+
+	// Try wrapped format first: {"traceEvents": [...]}
+	var wrapped chromeTrace
+	if err := json.Unmarshal(data, &wrapped); err == nil && len(wrapped.TraceEvents) > 0 {
+		events = wrapped.TraceEvents
+	} else {
+		// Try bare array: [...]
+		if err := json.Unmarshal(data, &events); err != nil {
+			return nil, fmt.Errorf("decode chrome trace JSON: %w", err)
+		}
+	}
+
+	return chromeEventsToSpans(events)
+}
+
+func chromeEventsToSpans(events []chromeEvent) ([]sdktrace.ReadOnlySpan, error) {
+	// Generate a deterministic trace ID from the events.
+	traceID := syntheticTraceID(events)
+
+	var stubs tracetest.SpanStubs
+
+	// Collect B/E pairs keyed by name+pid+tid.
+	type beginKey struct {
+		Name string
+		Pid  string
+		Tid  string
+	}
+	begins := make(map[beginKey]chromeEvent)
+
+	// Sort by timestamp to ensure B events come before their E events.
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].Ts < events[j].Ts
+	})
+
+	spanIndex := 0
+	for _, ev := range events {
+		switch ev.Ph {
+		case "X": // Complete event
+			stub := chromeEventToStub(ev, traceID, spanIndex)
+			stubs = append(stubs, stub)
+			spanIndex++
+
+		case "B": // Begin
+			key := beginKey{ev.Name, ev.Pid.String(), ev.Tid.String()}
+			begins[key] = ev
+
+		case "E": // End
+			key := beginKey{ev.Name, ev.Pid.String(), ev.Tid.String()}
+			if begin, ok := begins[key]; ok {
+				merged := begin
+				merged.Dur = ev.Ts - begin.Ts
+				// Merge args from end event
+				if len(ev.Args) > 0 {
+					if merged.Args == nil {
+						merged.Args = ev.Args
+					} else {
+						maps.Copy(merged.Args, ev.Args)
+					}
+				}
+				stub := chromeEventToStub(merged, traceID, spanIndex)
+				stubs = append(stubs, stub)
+				spanIndex++
+				delete(begins, key)
+			}
+
+		case "i", "I": // Instant event
+			instant := ev
+			instant.Dur = 0
+			stub := chromeEventToStub(instant, traceID, spanIndex)
+			stubs = append(stubs, stub)
+			spanIndex++
+		}
+	}
+
+	return stubs.Snapshots(), nil
+}
+
+func chromeEventToStub(ev chromeEvent, traceID trace.TraceID, index int) tracetest.SpanStub {
+	spanID := syntheticSpanID(traceID, index)
+
+	startMicros := ev.Ts
+	durMicros := ev.Dur
+
+	startTime := time.Unix(0, int64(startMicros*1000)) // micros → nanos
+	endTime := time.Unix(0, int64((startMicros+durMicros)*1000))
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	var attrs []attribute.KeyValue
+	if ev.Cat != "" {
+		attrs = append(attrs, attribute.String("chrome.category", ev.Cat))
+	}
+	attrs = append(attrs, attribute.String("chrome.pid", ev.Pid.String()))
+	attrs = append(attrs, attribute.String("chrome.tid", ev.Tid.String()))
+
+	for k, v := range ev.Args {
+		key := attribute.Key("chrome.args." + k)
+		switch val := v.(type) {
+		case string:
+			attrs = append(attrs, key.String(val))
+		case float64:
+			attrs = append(attrs, key.Float64(val))
+		case bool:
+			attrs = append(attrs, key.Bool(val))
+		default:
+			attrs = append(attrs, key.String(fmt.Sprintf("%v", val)))
+		}
+	}
+
+	return tracetest.SpanStub{
+		Name:        ev.Name,
+		SpanContext: sc,
+		StartTime:   startTime,
+		EndTime:     endTime,
+		Attributes:  attrs,
+	}
+}
+
+// syntheticTraceID generates a deterministic trace ID by hashing event data.
+func syntheticTraceID(events []chromeEvent) trace.TraceID {
+	h := sha256.New()
+	for _, ev := range events {
+		fmt.Fprintf(h, "%s:%s:%.0f", ev.Name, ev.Ph, ev.Ts)
+	}
+	var tid trace.TraceID
+	copy(tid[:], h.Sum(nil)[:16])
+	return tid
+}
+
+// syntheticSpanID generates a deterministic span ID from trace ID and index.
+func syntheticSpanID(traceID trace.TraceID, index int) trace.SpanID {
+	h := sha256.New()
+	h.Write(traceID[:])
+	binary.Write(h, binary.BigEndian, int64(index))
+	var sid trace.SpanID
+	copy(sid[:], h.Sum(nil)[:8])
+	return sid
+}

--- a/pkg/ingest/otlpfile/otlpfile.go
+++ b/pkg/ingest/otlpfile/otlpfile.go
@@ -94,6 +94,12 @@ func Parse(r io.Reader) ([]sdktrace.ReadOnlySpan, error) {
 		return ParseProto(bytes.NewReader(data))
 	}
 
+	// Detect Chrome Tracing format by looking for "traceEvents" key or
+	// "ph" field (event phase indicator unique to Chrome Tracing).
+	if bytes.Contains(data, []byte(`"traceEvents"`)) || looksLikeChromeTrace(data) {
+		return ParseChrome(bytes.NewReader(data))
+	}
+
 	return parseStdout(bytes.NewReader(data))
 }
 
@@ -240,6 +246,26 @@ func convertAttr(a attrJSON) attribute.KeyValue {
 		}
 	}
 	return key.String(fmt.Sprintf("%v", a.Value.Value))
+}
+
+// looksLikeChromeTrace checks for bare-array Chrome Tracing format
+// by looking for the "ph" key (event phase) which is unique to Chrome Tracing.
+func looksLikeChromeTrace(data []byte) bool {
+	// Check for "ph": pattern — the "ph" JSON key followed by a colon.
+	for i := 0; i < len(data)-4; i++ {
+		if data[i] == '"' && data[i+1] == 'p' && data[i+2] == 'h' && data[i+3] == '"' {
+			// Look for colon after optional whitespace
+			for j := i + 4; j < len(data); j++ {
+				if data[j] == ':' {
+					return true
+				}
+				if data[j] != ' ' && data[j] != '\t' {
+					break
+				}
+			}
+		}
+	}
+	return false
 }
 
 func trimSpace(b []byte) []byte {

--- a/pkg/ingest/otlpfile/otlpfile_test.go
+++ b/pkg/ingest/otlpfile/otlpfile_test.go
@@ -376,6 +376,150 @@ func TestParseProtoAttributeTypes(t *testing.T) {
 	}
 }
 
+func TestParseChromeTraceWrapped(t *testing.T) {
+	input := `{
+		"traceEvents": [
+			{"name":"CompileC","ph":"X","ts":1000000,"dur":500000,"pid":1,"tid":1,"cat":"cc","args":{"file":"main.c"}},
+			{"name":"Link","ph":"X","ts":1500000,"dur":200000,"pid":1,"tid":2,"cat":"link"}
+		]
+	}`
+
+	spans, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(spans) != 2 {
+		t.Fatalf("expected 2 spans, got %d", len(spans))
+	}
+
+	if spans[0].Name() != "CompileC" {
+		t.Errorf("span[0] name = %q, want %q", spans[0].Name(), "CompileC")
+	}
+	if spans[1].Name() != "Link" {
+		t.Errorf("span[1] name = %q, want %q", spans[1].Name(), "Link")
+	}
+
+	// Check timing: 1000000 microseconds = 1 second
+	expectedStart := time.Unix(1, 0)
+	if !spans[0].StartTime().Equal(expectedStart) {
+		t.Errorf("span[0] start = %v, want %v", spans[0].StartTime(), expectedStart)
+	}
+	expectedEnd := time.Unix(1, 500000000) // 1.5 seconds
+	if !spans[0].EndTime().Equal(expectedEnd) {
+		t.Errorf("span[0] end = %v, want %v", spans[0].EndTime(), expectedEnd)
+	}
+
+	// Check attributes
+	attrs := spans[0].Attributes()
+	var foundCat, foundArg bool
+	for _, a := range attrs {
+		if string(a.Key) == "chrome.category" && a.Value.AsString() == "cc" {
+			foundCat = true
+		}
+		if string(a.Key) == "chrome.args.file" && a.Value.AsString() == "main.c" {
+			foundArg = true
+		}
+	}
+	if !foundCat {
+		t.Errorf("missing chrome.category=cc attribute")
+	}
+	if !foundArg {
+		t.Errorf("missing chrome.args.file=main.c attribute")
+	}
+}
+
+func TestParseChromeTraceBareArray(t *testing.T) {
+	input := `[
+		{"name":"Task","ph":"X","ts":0,"dur":100000,"pid":1,"tid":1},
+		{"name":"Subtask","ph":"X","ts":10000,"dur":50000,"pid":1,"tid":1}
+	]`
+
+	spans, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(spans) != 2 {
+		t.Fatalf("expected 2 spans, got %d", len(spans))
+	}
+	if spans[0].Name() != "Task" {
+		t.Errorf("span[0] name = %q, want %q", spans[0].Name(), "Task")
+	}
+}
+
+func TestParseChromeTraceBeginEnd(t *testing.T) {
+	input := `{"traceEvents": [
+		{"name":"LongOp","ph":"B","ts":1000000,"pid":1,"tid":1},
+		{"name":"LongOp","ph":"E","ts":2000000,"pid":1,"tid":1,"args":{"result":"ok"}}
+	]}`
+
+	spans, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].Name() != "LongOp" {
+		t.Errorf("name = %q, want %q", spans[0].Name(), "LongOp")
+	}
+
+	// Duration should be 1 second
+	dur := spans[0].EndTime().Sub(spans[0].StartTime())
+	if dur != time.Second {
+		t.Errorf("duration = %v, want 1s", dur)
+	}
+
+	// Check merged args from E event
+	var foundResult bool
+	for _, a := range spans[0].Attributes() {
+		if string(a.Key) == "chrome.args.result" && a.Value.AsString() == "ok" {
+			foundResult = true
+		}
+	}
+	if !foundResult {
+		t.Errorf("missing chrome.args.result=ok from end event")
+	}
+}
+
+func TestParseChromeTraceInstant(t *testing.T) {
+	input := `{"traceEvents": [
+		{"name":"Marker","ph":"i","ts":5000000,"pid":1,"tid":1,"s":"g"}
+	]}`
+
+	spans, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].Name() != "Marker" {
+		t.Errorf("name = %q, want %q", spans[0].Name(), "Marker")
+	}
+	// Instant events should have zero duration
+	if !spans[0].StartTime().Equal(spans[0].EndTime()) {
+		t.Errorf("instant event should have start == end")
+	}
+}
+
+func TestParseChromeTraceSkipsMetadata(t *testing.T) {
+	input := `{"traceEvents": [
+		{"name":"process_name","ph":"M","pid":1,"args":{"name":"Browser"}},
+		{"name":"RealWork","ph":"X","ts":1000,"dur":500,"pid":1,"tid":1}
+	]}`
+
+	spans, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span (metadata skipped), got %d", len(spans))
+	}
+	if spans[0].Name() != "RealWork" {
+		t.Errorf("name = %q, want %q", spans[0].Name(), "RealWork")
+	}
+}
+
 func TestStatusFromCode(t *testing.T) {
 	tests := []struct {
 		code string

--- a/pkg/output/styled.go
+++ b/pkg/output/styled.go
@@ -70,11 +70,82 @@ func OutputStyledResults(w io.Writer, urlResults []analyzer.URLResult, combined 
 	rightPlain3 := fmt.Sprintf("Concurrency: %d", combined.MaxConcurrency)
 	line3 := buildLineAligned(contentWidth, leftStyled3, leftPlain3, rightStyled3, rightPlain3)
 
+	// Aggregate enrichment metrics across URL results
+	var totalQueueTimes []float64
+	var totalRetriedRuns, totalRunCount int
+	totalBillable := map[string]int64{}
+	totalRunnerJobs := map[string]int{}
+	totalRunnerDur := map[string]float64{}
+	for _, result := range urlResults {
+		totalQueueTimes = append(totalQueueTimes, result.Metrics.QueueTimes...)
+		totalRetriedRuns += result.Metrics.RetriedRuns
+		totalRunCount += result.Metrics.TotalRuns
+		for os, ms := range result.Metrics.BillableMs {
+			totalBillable[os] += ms
+		}
+		for runner, count := range result.Metrics.RunnerJobCounts {
+			totalRunnerJobs[runner] += count
+		}
+		for runner, dur := range result.Metrics.RunnerDurations {
+			totalRunnerDur[runner] += dur
+		}
+	}
+
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, topBorder)
 	fmt.Fprintln(w, line1)
 	fmt.Fprintln(w, line2)
 	fmt.Fprintln(w, line3)
+
+	// Line 4: Queue time + Retry rate (conditional)
+	hasQueueData := len(totalQueueTimes) > 0
+	hasRetryData := totalRetriedRuns > 0
+	if hasQueueData || hasRetryData {
+		var parts4 []string
+		if hasQueueData {
+			avgQ := 0.0
+			maxQ := 0.0
+			for _, qt := range totalQueueTimes {
+				avgQ += qt
+				if qt > maxQ {
+					maxQ = qt
+				}
+			}
+			avgQ /= float64(len(totalQueueTimes))
+			avgQStr := utils.HumanizeTime(avgQ / 1000)
+			maxQStr := utils.HumanizeTime(maxQ / 1000)
+			parts4 = append(parts4, labelStyle.Render("Queue: avg ")+numStyle.Render(avgQStr)+labelStyle.Render(" / max ")+numStyle.Render(maxQStr))
+		}
+		if hasRetryData {
+			retryPct := fmt.Sprintf("%.0f%%", float64(totalRetriedRuns)/float64(totalRunCount)*100)
+			retryDetail := fmt.Sprintf("(%d/%d runs)", totalRetriedRuns, totalRunCount)
+			parts4 = append(parts4, labelStyle.Render("Retries: ")+numStyle.Render(retryPct)+" "+labelStyle.Render(retryDetail))
+		}
+		fmt.Fprintln(w, buildLeftLine(strings.Join(parts4, sep)))
+	}
+
+	// Line 5: Billable timing (conditional)
+	if len(totalBillable) > 0 {
+		osNames := map[string]string{"UBUNTU": "Ubuntu", "MACOS": "macOS", "WINDOWS": "Windows"}
+		var billParts []string
+		for _, osKey := range []string{"UBUNTU", "MACOS", "WINDOWS"} {
+			ms := totalBillable[osKey]
+			durStr := utils.HumanizeTime(float64(ms) / 1000)
+			billParts = append(billParts, labelStyle.Render(osNames[osKey]+" ")+numStyle.Render(durStr))
+		}
+		fmt.Fprintln(w, buildLeftLine(labelStyle.Render("Billable: ")+strings.Join(billParts, "  ")))
+	}
+
+	// Line 6: Runner distribution (conditional)
+	if len(totalRunnerJobs) > 0 {
+		var runnerParts []string
+		for runner, count := range totalRunnerJobs {
+			dur := totalRunnerDur[runner]
+			durStr := utils.HumanizeTime(dur / 1000)
+			runnerParts = append(runnerParts, numStyle.Render(runner)+labelStyle.Render(fmt.Sprintf(" ×%d ", count))+dimStyle.Render("("+durStr+")"))
+		}
+		fmt.Fprintln(w, buildLeftLine(labelStyle.Render("Runners: ")+strings.Join(runnerParts, "  ")))
+	}
 
 	// URL lines inside header box
 	for _, result := range urlResults {


### PR DESCRIPTION
## Summary

- **OTel-native refactor**: Replace SpanCollector/TracerProvider roundtrip with direct SpanStub construction via SpanBuilder; add SpanHints-based enrichment system for classifying spans
- **Trace input support**: Add `--trace=<file>`, `--tempo=<url>`, `--jaeger=<url>` flags to load/fetch external OTel traces and merge with GHA spans
- **Queue time**: Emit ⏳ Queued child spans (job.CreatedAt → job.StartedAt), add `queue_time_ms` attribute, compute avg/max in metrics
- **Runner distribution**: Track per-runner job counts and durations (replaces simple set), show in styled header
- **Billable timing**: Fetch `/actions/runs/{id}/timing` API, add `billable.*_ms` attributes to workflow spans
- **Annotations**: Fetch check run annotations for failed jobs, attach as OTel span events
- **Retry detection**: Detect `run_attempt > 1`, add `github.run_attempt` attribute, compute retry rate
- **Trace artifact ingest**: Download `gha-trace.*` artifacts, parse OTLP JSON from zips, merge into trace tree (`--no-artifacts` to disable)
- **K8s attributes**: Add `k8s.pod.name` to job spans when runner name is set

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `bazel build //...` — all targets compile
- [x] `bazel test //...` — all 12 test targets pass
- [ ] Run against a real GitHub PR URL and verify queued spans, annotations, billable data, runner distribution in output
- [ ] Verify `--no-artifacts` flag is recognized and skips artifact download
- [ ] Verify `--trace=<file>` loads external spans into TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)