### PR TITLE
Add workflow-level queue time span

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -396,6 +396,45 @@ func processWorkflowRun(ctx context.Context, run githubapi.WorkflowRun, runIndex
 		},
 	})
 
+	// Emit workflow-level queue span (CreatedAt → RunStartedAt)
+	if run.RunStartedAt != "" {
+		if runStartedAt, ok := utils.ParseTime(run.RunStartedAt); ok && runStartedAt.After(runStart) {
+			queueDurMs := runStartedAt.UnixMilli() - runStartTs
+			normalizedQueueStart := (runStartTs - earliestTime) * 1000
+			normalizedQueueEnd := (runStartedAt.UnixMilli() - earliestTime) * 1000
+			traceEvents = append(traceEvents, TraceEvent{
+				Name: fmt.Sprintf("⏳ Workflow Queued [%d]", urlIndex+1),
+				Ph:   "X",
+				Ts:   normalizedQueueStart,
+				Dur:  normalizedQueueEnd - normalizedQueueStart,
+				Pid:  processID,
+				Tid:  workflowThreadID,
+				Cat:  "queued",
+				Args: map[string]interface{}{
+					"type":          "workflow_queued",
+					"queue_time_ms": queueDurMs,
+				},
+			})
+
+			queueSID := githubapi.NewSpanIDFromString(fmt.Sprintf("wf-queued-%d", run.ID))
+			builder.Add(tracetest.SpanStub{
+				Name: "⏳ Workflow Queued",
+				SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+					TraceID:    tid,
+					SpanID:     queueSID,
+					TraceFlags: trace.FlagsSampled,
+				}),
+				Parent:    wfSC,
+				StartTime: runStart,
+				EndTime:   runStartedAt,
+				Attributes: []attribute.KeyValue{
+					attribute.String("type", "workflow_queued"),
+					attribute.Int64("queue_time_ms", queueDurMs),
+				},
+			})
+		}
+	}
+
 	// Fetch annotations for failed check runs (best-effort)
 	jobAnnotations := map[string][]githubapi.Annotation{}
 	checkRuns, err := client.FetchCheckRunsForCommit(ctx, run.Repository.Owner.Login, run.Repository.Name, run.HeadSHA)

--- a/pkg/analyzer/otel_test.go
+++ b/pkg/analyzer/otel_test.go
@@ -96,6 +96,198 @@ func (m *mockGitHubProvider) DownloadArtifact(ctx context.Context, url string) (
 	return args.Get(0).([]byte), args.Error(1)
 }
 
+func TestWorkflowQueueTimeSpan(t *testing.T) {
+	t.Run("emits workflow queue span when RunStartedAt is after CreatedAt", func(t *testing.T) {
+		mockClient := new(mockGitHubProvider)
+		builder := &SpanBuilder{}
+
+		run := githubapi.WorkflowRun{
+			ID:           100,
+			RunAttempt:   1,
+			Name:         "CI",
+			Status:       "completed",
+			Conclusion:   "success",
+			CreatedAt:    "2026-03-18T17:17:33Z",
+			RunStartedAt: "2026-03-18T17:47:58Z",
+			UpdatedAt:    "2026-03-18T18:50:30Z",
+			HeadSHA:      "abc123",
+			Repository: githubapi.RepoRef{
+				Owner: githubapi.RepoOwner{Login: "owner"},
+				Name:  "repo",
+			},
+		}
+
+		job := githubapi.Job{
+			ID:          200,
+			Name:        "Build",
+			Status:      "completed",
+			Conclusion:  "success",
+			CreatedAt:   "2026-03-18T17:47:58Z",
+			StartedAt:   "2026-03-18T17:56:49Z",
+			CompletedAt: "2026-03-18T18:47:19Z",
+			RunnerName:  "runner-1",
+		}
+
+		jobsURL := "https://api.github.com/repos/owner/repo/actions/runs/100/jobs?per_page=100"
+		mockClient.On("FetchJobsPaginated", mock.Anything, jobsURL).Return([]githubapi.Job{job}, nil)
+		mockClient.On("FetchCheckRunsForCommit", mock.Anything, "owner", "repo", "abc123").Return([]githubapi.CheckRun{}, nil)
+		mockClient.On("FetchRunTiming", mock.Anything, "owner", "repo", int64(100)).Return((*githubapi.RunTiming)(nil), nil)
+		mockClient.On("ListArtifacts", mock.Anything, "owner", "repo", int64(100)).Return([]githubapi.Artifact{}, nil)
+
+		createdAt, _ := utils.ParseTime(run.CreatedAt)
+		earliestTime := createdAt.UnixMilli()
+
+		_, traceEvents, _, _, err := processWorkflowRun(
+			context.Background(), run, 0, 1001, earliestTime,
+			"owner", "repo", "1", 0, "https://github.com/owner/repo/pull/1", "pr",
+			nil, mockClient, nil, builder, AnalyzeOptions{NoArtifacts: true},
+		)
+		assert.NoError(t, err)
+
+		// Check trace events for workflow queue span
+		var wfQueueFound bool
+		for _, event := range traceEvents {
+			if event.Cat == "queued" && event.Args["type"] == "workflow_queued" {
+				wfQueueFound = true
+				queueMs := event.Args["queue_time_ms"].(int64)
+				// 17:47:58 - 17:17:33 = 30m25s = 1825000ms
+				assert.Equal(t, int64(1825000), queueMs)
+				assert.Equal(t, int64(0), event.Ts, "should start at normalized time 0 (earliest)")
+			}
+		}
+		assert.True(t, wfQueueFound, "Workflow queue trace event not found")
+
+		// Check OTel spans for workflow queue span
+		spans := builder.Spans()
+		var otelQueueFound bool
+		for _, s := range spans {
+			if s.Name() == "⏳ Workflow Queued" {
+				otelQueueFound = true
+				attrs := map[string]interface{}{}
+				for _, a := range s.Attributes() {
+					attrs[string(a.Key)] = a.Value.AsInterface()
+				}
+				assert.Equal(t, "workflow_queued", attrs["type"])
+				assert.Equal(t, int64(1825000), attrs["queue_time_ms"])
+
+				expectedStart, _ := utils.ParseTime("2026-03-18T17:17:33Z")
+				expectedEnd, _ := utils.ParseTime("2026-03-18T17:47:58Z")
+				assert.Equal(t, expectedStart, s.StartTime())
+				assert.Equal(t, expectedEnd, s.EndTime())
+			}
+		}
+		assert.True(t, otelQueueFound, "Workflow queue OTel span not found")
+	})
+
+	t.Run("no queue span when RunStartedAt equals CreatedAt", func(t *testing.T) {
+		mockClient := new(mockGitHubProvider)
+		builder := &SpanBuilder{}
+
+		run := githubapi.WorkflowRun{
+			ID:           101,
+			RunAttempt:   1,
+			Name:         "CI",
+			Status:       "completed",
+			Conclusion:   "success",
+			CreatedAt:    "2026-03-18T17:17:33Z",
+			RunStartedAt: "2026-03-18T17:17:33Z",
+			UpdatedAt:    "2026-03-18T17:30:00Z",
+			HeadSHA:      "abc123",
+			Repository: githubapi.RepoRef{
+				Owner: githubapi.RepoOwner{Login: "owner"},
+				Name:  "repo",
+			},
+		}
+
+		job := githubapi.Job{
+			ID:          201,
+			Name:        "Build",
+			Status:      "completed",
+			Conclusion:  "success",
+			CreatedAt:   "2026-03-18T17:17:33Z",
+			StartedAt:   "2026-03-18T17:17:40Z",
+			CompletedAt: "2026-03-18T17:30:00Z",
+			RunnerName:  "runner-1",
+		}
+
+		jobsURL := "https://api.github.com/repos/owner/repo/actions/runs/101/jobs?per_page=100"
+		mockClient.On("FetchJobsPaginated", mock.Anything, jobsURL).Return([]githubapi.Job{job}, nil)
+		mockClient.On("FetchCheckRunsForCommit", mock.Anything, "owner", "repo", "abc123").Return([]githubapi.CheckRun{}, nil)
+		mockClient.On("FetchRunTiming", mock.Anything, "owner", "repo", int64(101)).Return((*githubapi.RunTiming)(nil), nil)
+		mockClient.On("ListArtifacts", mock.Anything, "owner", "repo", int64(101)).Return([]githubapi.Artifact{}, nil)
+
+		createdAt, _ := utils.ParseTime(run.CreatedAt)
+		earliestTime := createdAt.UnixMilli()
+
+		_, traceEvents, _, _, err := processWorkflowRun(
+			context.Background(), run, 0, 1001, earliestTime,
+			"owner", "repo", "1", 0, "https://github.com/owner/repo/pull/1", "pr",
+			nil, mockClient, nil, builder, AnalyzeOptions{NoArtifacts: true},
+		)
+		assert.NoError(t, err)
+
+		for _, event := range traceEvents {
+			if event.Args != nil && event.Args["type"] == "workflow_queued" {
+				t.Fatal("Should not emit workflow queue span when RunStartedAt == CreatedAt")
+			}
+		}
+	})
+
+	t.Run("no queue span when RunStartedAt is empty", func(t *testing.T) {
+		mockClient := new(mockGitHubProvider)
+		builder := &SpanBuilder{}
+
+		run := githubapi.WorkflowRun{
+			ID:           102,
+			RunAttempt:   1,
+			Name:         "CI",
+			Status:       "completed",
+			Conclusion:   "success",
+			CreatedAt:    "2026-03-18T17:17:33Z",
+			RunStartedAt: "",
+			UpdatedAt:    "2026-03-18T17:30:00Z",
+			HeadSHA:      "abc123",
+			Repository: githubapi.RepoRef{
+				Owner: githubapi.RepoOwner{Login: "owner"},
+				Name:  "repo",
+			},
+		}
+
+		job := githubapi.Job{
+			ID:          202,
+			Name:        "Build",
+			Status:      "completed",
+			Conclusion:  "success",
+			CreatedAt:   "2026-03-18T17:17:33Z",
+			StartedAt:   "2026-03-18T17:17:40Z",
+			CompletedAt: "2026-03-18T17:30:00Z",
+			RunnerName:  "runner-1",
+		}
+
+		jobsURL := "https://api.github.com/repos/owner/repo/actions/runs/102/jobs?per_page=100"
+		mockClient.On("FetchJobsPaginated", mock.Anything, jobsURL).Return([]githubapi.Job{job}, nil)
+		mockClient.On("FetchCheckRunsForCommit", mock.Anything, "owner", "repo", "abc123").Return([]githubapi.CheckRun{}, nil)
+		mockClient.On("FetchRunTiming", mock.Anything, "owner", "repo", int64(102)).Return((*githubapi.RunTiming)(nil), nil)
+		mockClient.On("ListArtifacts", mock.Anything, "owner", "repo", int64(102)).Return([]githubapi.Artifact{}, nil)
+
+		createdAt, _ := utils.ParseTime(run.CreatedAt)
+		earliestTime := createdAt.UnixMilli()
+
+		_, traceEvents, _, _, err := processWorkflowRun(
+			context.Background(), run, 0, 1001, earliestTime,
+			"owner", "repo", "1", 0, "https://github.com/owner/repo/pull/1", "pr",
+			nil, mockClient, nil, builder, AnalyzeOptions{NoArtifacts: true},
+		)
+		assert.NoError(t, err)
+
+		for _, event := range traceEvents {
+			if event.Args != nil && event.Args["type"] == "workflow_queued" {
+				t.Fatal("Should not emit workflow queue span when RunStartedAt is empty")
+			}
+		}
+	})
+}
+
 func TestSpanBuilderGeneration(t *testing.T) {
 	mockClient := new(mockGitHubProvider)
 

--- a/pkg/githubapi/client.go
+++ b/pkg/githubapi/client.go
@@ -130,16 +130,17 @@ type WorkflowRunsResponse struct {
 }
 
 type WorkflowRun struct {
-	ID         int64   `json:"id"`
-	RunAttempt int64   `json:"run_attempt"`
-	Name       string  `json:"name"`
-	Path       string  `json:"path"`
-	Status     string  `json:"status"`
-	Conclusion string  `json:"conclusion"`
-	CreatedAt  string  `json:"created_at"`
-	UpdatedAt  string  `json:"updated_at"`
-	HeadSHA    string  `json:"head_sha"`
-	Repository RepoRef `json:"repository"`
+	ID           int64   `json:"id"`
+	RunAttempt   int64   `json:"run_attempt"`
+	Name         string  `json:"name"`
+	Path         string  `json:"path"`
+	Status       string  `json:"status"`
+	Conclusion   string  `json:"conclusion"`
+	CreatedAt    string  `json:"created_at"`
+	RunStartedAt string  `json:"run_started_at"`
+	UpdatedAt    string  `json:"updated_at"`
+	HeadSHA      string  `json:"head_sha"`
+	Repository   RepoRef `json:"repository"`
 }
 
 type RepoRef struct {


### PR DESCRIPTION
## Summary

- Parse `run_started_at` from the GitHub Actions workflow run API response
- Emit a "⏳ Workflow Queued" trace event and OTel span for the gap between `created_at` → `run_started_at`
- This surfaces the workflow-level queue time that was previously invisible (can be 30+ minutes during peak hours)

### Before

The workflow span starts at `created_at` and the first job span starts at `job.started_at`. The gap between them appeared as unexplained dead space — no span, no label.

### After

A `⏳ Workflow Queued` span fills the gap on the Workflow Overview thread, making it immediately visible in both the TUI timeline and Perfetto exports.

### Context

Discovered while analyzing linkedin-multiproduct/mint PR #3450 where the post-merge run showed 1h32m wall clock but the first job didn't start until 39 minutes in. The GitHub API provides three timestamps:
- `created_at`: workflow run created (PR event fired)
- `run_started_at`: workflow transitions to in_progress (first runner assigned)
- `updated_at`: workflow last updated

Only `created_at` and `updated_at` were being parsed; `run_started_at` was ignored.

## Test plan

- [x] New test: emits queue span when run_started_at is after created_at (30m25s gap from real data)
- [x] New test: no queue span when run_started_at equals created_at
- [x] New test: no queue span when run_started_at is empty
- [x] All existing tests pass