### PR TITLE
Add ARC OTel trace recorder for runner-level visibility

### DIFF
--- a/cmd/arc-sim/BUILD.bazel
+++ b/cmd/arc-sim/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "arc-sim_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/stefanpenner/otel-explorer/cmd/arc-sim",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/arc",
+        "//pkg/githubapi",
+        "@io_opentelemetry_go_otel_exporters_otlp_otlptrace_otlptracehttp//:otlptracehttp",
+    ],
+)
+
+go_binary(
+    name = "arc-sim",
+    embed = [":arc-sim_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/arc-sim/main.go
+++ b/cmd/arc-sim/main.go
@@ -1,0 +1,171 @@
+// arc-sim simulates ARC (Actions Runner Controller) OTel span emission
+// for a real GitHub Actions workflow run. It fetches job data from the
+// GitHub API, constructs matching JobCompleted messages with plausible
+// runner lifecycle timestamps, and sends them through the OTelRecorder.
+//
+// Usage:
+//
+//	arc-sim --run=<owner/repo/runID> --endpoint=localhost:4318
+//	arc-sim --run=stefanpenner/otel-explorer/15088041641 --endpoint=localhost:4318
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/stefanpenner/otel-explorer/pkg/arc"
+	"github.com/stefanpenner/otel-explorer/pkg/githubapi"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+)
+
+func main() {
+	run := flag.String("run", "", "owner/repo/runID (required)")
+	endpoint := flag.String("endpoint", "localhost:4318", "OTLP HTTP endpoint")
+	insecure := flag.Bool("insecure", true, "use HTTP instead of HTTPS")
+	queueDelay := flag.Duration("queue-delay", 3*time.Second, "simulated queue wait before ARC picks up the job")
+	startupDelay := flag.Duration("startup-delay", 8*time.Second, "simulated runner pod startup time")
+	flag.Parse()
+
+	if *run == "" {
+		fmt.Fprintln(os.Stderr, "Usage: arc-sim --run=owner/repo/runID [--endpoint=host:port]")
+		os.Exit(1)
+	}
+
+	parts := strings.SplitN(*run, "/", 3)
+	if len(parts) != 3 {
+		log.Fatalf("--run must be owner/repo/runID, got %q", *run)
+	}
+	owner, repo := parts[0], parts[1]
+	runID, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		log.Fatalf("invalid runID %q: %v", parts[2], err)
+	}
+
+	ctx := context.Background()
+
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		if ghPath, err := exec.LookPath("gh"); err == nil {
+			if out, err := exec.Command(ghPath, "auth", "token").Output(); err == nil {
+				token = strings.TrimSpace(string(out))
+			}
+		}
+	}
+	if token == "" {
+		log.Fatal("GITHUB_TOKEN not set and gh CLI not available")
+	}
+
+	ghCtx := githubapi.NewContext(token)
+	client := githubapi.NewClient(ghCtx)
+
+	// Fetch real workflow run and jobs
+	log.Printf("Fetching workflow run %s/%s/%d ...", owner, repo, runID)
+	wfRun, err := client.FetchWorkflowRun(ctx, owner, repo, runID)
+	if err != nil {
+		log.Fatalf("Failed to fetch workflow run: %v", err)
+	}
+	log.Printf("Workflow: %s (status=%s, conclusion=%s)", wfRun.Name, wfRun.Status, wfRun.Conclusion)
+
+	jobsURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/actions/runs/%d/attempts/%d/jobs?per_page=100",
+		owner, repo, runID, wfRun.RunAttempt)
+	jobs, err := client.FetchJobsPaginated(ctx, jobsURL)
+	if err != nil {
+		log.Fatalf("Failed to fetch jobs: %v", err)
+	}
+	log.Printf("Found %d jobs", len(jobs))
+
+	// Create OTLP exporter
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint(*endpoint),
+	}
+	if *insecure {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	}
+	exporter, err := otlptracehttp.New(ctx, opts...)
+	if err != nil {
+		log.Fatalf("Failed to create OTLP exporter: %v", err)
+	}
+	defer exporter.Shutdown(ctx)
+
+	recorder := arc.NewOTelRecorder(exporter)
+	recorder.SetRunAttempt(wfRun.RunAttempt)
+
+	// Simulate ARC messages for each completed job
+	for _, job := range jobs {
+		if job.Status != "completed" {
+			log.Printf("  Skipping %s (status=%s)", job.Name, job.Status)
+			continue
+		}
+
+		createdAt := parseTime(job.CreatedAt)
+		startedAt := parseTime(job.StartedAt)
+		completedAt := parseTime(job.CompletedAt)
+
+		// Simulate ARC timestamps:
+		// QueueTime = when GitHub queued the job
+		// ScaleSetAssignTime = QueueTime + small delay (ARC picks it up)
+		// RunnerAssignTime = when the runner actually started (from GitHub API)
+		// FinishTime = when the job completed
+		queueTime := createdAt
+		scaleSetAssignTime := createdAt.Add(*queueDelay)
+		runnerAssignTime := startedAt
+		finishTime := completedAt
+
+		// If simulated startup would exceed actual start, clamp it
+		if scaleSetAssignTime.Add(*startupDelay).After(runnerAssignTime) && runnerAssignTime.After(scaleSetAssignTime) {
+			// Keep scaleSetAssignTime as is, runner was fast
+		} else if scaleSetAssignTime.After(runnerAssignTime) {
+			// ARC pickup was slower than actual start — clamp
+			scaleSetAssignTime = queueTime.Add(time.Second)
+		}
+
+		msg := &arc.JobCompleted{
+			JobMessageBase: arc.JobMessageBase{
+				RunnerRequestID:    job.ID,
+				WorkflowRunID:      runID,
+				JobID:              strconv.FormatInt(job.ID, 10),
+				JobDisplayName:     job.Name,
+				OwnerName:          owner,
+				RepositoryName:     repo,
+				JobWorkflowRef:     fmt.Sprintf("%s/%s/%s@refs/heads/%s", owner, repo, wfRun.Path, wfRun.HeadBranch),
+				EventName:          "push",
+				QueueTime:          queueTime,
+				ScaleSetAssignTime: scaleSetAssignTime,
+				RunnerAssignTime:   runnerAssignTime,
+				FinishTime:         finishTime,
+			},
+			Result:     job.Conclusion,
+			RunnerName: job.RunnerName,
+			RunnerID:   int(job.ID % 1000),
+		}
+
+		log.Printf("  Sending spans for job %q (ID=%d): queue=%s startup=%s exec=%s",
+			job.Name, job.ID,
+			scaleSetAssignTime.Sub(queueTime),
+			runnerAssignTime.Sub(scaleSetAssignTime),
+			finishTime.Sub(runnerAssignTime),
+		)
+
+		recorder.RecordJobCompleted(msg)
+	}
+
+	// Give exporter time to flush
+	time.Sleep(2 * time.Second)
+	log.Println("Done. Spans exported.")
+}
+
+func parseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "e2e_test",
+    srcs = ["arc_integration_test.go"],
+    deps = [
+        "//pkg/arc",
+        "//pkg/enrichment",
+        "//pkg/githubapi",
+        "//pkg/ingest/receiver",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_otel_exporters_otlp_otlptrace_otlptracehttp//:otlptracehttp",
+        "@io_opentelemetry_go_otel_sdk//trace",
+    ],
+)

--- a/e2e/arc_integration_test.go
+++ b/e2e/arc_integration_test.go
@@ -1,0 +1,259 @@
+// Package e2e tests the full ARC → OTLP → otel-explorer pipeline.
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stefanpenner/otel-explorer/pkg/arc"
+	"github.com/stefanpenner/otel-explorer/pkg/enrichment"
+	"github.com/stefanpenner/otel-explorer/pkg/githubapi"
+	"github.com/stefanpenner/otel-explorer/pkg/ingest/receiver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+)
+
+// TestLevel1_RecorderToReceiver verifies the full OTLP pipeline:
+// OTelRecorder → OTLP/HTTP → otel-explorer receiver → enricher
+func TestLevel1_RecorderToReceiver(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Start OTLP receiver on a random port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	recv := receiver.New(addr)
+	go recv.Start(ctx)
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://%s/health", addr))
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == 200
+	}, 5*time.Second, 50*time.Millisecond, "receiver did not become ready")
+
+	// Create OTLP exporter pointed at receiver
+	exporter, err := otlptracehttp.New(ctx,
+		otlptracehttp.WithEndpoint(addr),
+		otlptracehttp.WithInsecure(),
+	)
+	require.NoError(t, err)
+
+	recorder := arc.NewOTelRecorder(exporter)
+
+	runID := int64(99999)
+	jobID := int64(42)
+	attempt := int64(1)
+	recorder.SetRunAttempt(attempt)
+
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+	recorder.RecordJobCompleted(&arc.JobCompleted{
+		JobMessageBase: arc.JobMessageBase{
+			RunnerRequestID:    1,
+			WorkflowRunID:      runID,
+			JobID:              strconv.FormatInt(jobID, 10),
+			JobDisplayName:     "build",
+			OwnerName:          "acme",
+			RepositoryName:     "widgets",
+			JobWorkflowRef:     "acme/widgets/.github/workflows/ci.yml@refs/heads/main",
+			EventName:          "push",
+			QueueTime:          now,
+			ScaleSetAssignTime: now.Add(5 * time.Second),
+			RunnerAssignTime:   now.Add(15 * time.Second),
+			FinishTime:         now.Add(3 * time.Minute),
+		},
+		Result:     "succeeded",
+		RunnerID:   7,
+		RunnerName: "runner-abc",
+	})
+
+	// Flush exporter
+	require.NoError(t, exporter.Shutdown(ctx))
+
+	// Wait for receiver to accumulate spans (OTLP HTTP is async)
+	var spans []sdktrace.ReadOnlySpan
+	require.Eventually(t, func() bool {
+		spans = recv.Spans()
+		return len(spans) == 3
+	}, 5*time.Second, 50*time.Millisecond, "expected 3 spans, got %d", recv.SpanCount())
+
+	expectedTraceID := githubapi.NewTraceID(runID, attempt)
+	expectedParentSpanID := githubapi.NewSpanID(jobID)
+
+	byName := map[string]sdktrace.ReadOnlySpan{}
+	for _, s := range spans {
+		byName[s.Name()] = s
+	}
+
+	for name, s := range byName {
+		assert.Equal(t, expectedTraceID, s.SpanContext().TraceID(), "trace ID mismatch on %s", name)
+		assert.Equal(t, expectedParentSpanID, s.Parent().SpanID(), "parent span ID mismatch on %s", name)
+	}
+
+	// Protobuf roundtrip loses timezone (stores as unix nanos), so compare unix times
+	q := byName["runner.queue"]
+	require.NotNil(t, q)
+	assert.Equal(t, now.UnixNano(), q.StartTime().UnixNano())
+	assert.Equal(t, now.Add(5*time.Second).UnixNano(), q.EndTime().UnixNano())
+	assertAttr(t, q, "type", "runner.queue")
+
+	s := byName["runner.startup"]
+	require.NotNil(t, s)
+	assert.Equal(t, now.Add(5*time.Second).UnixNano(), s.StartTime().UnixNano())
+	assert.Equal(t, now.Add(15*time.Second).UnixNano(), s.EndTime().UnixNano())
+	assertAttr(t, s, "type", "runner.startup")
+
+	e := byName["runner.execution"]
+	require.NotNil(t, e)
+	assert.Equal(t, now.Add(15*time.Second).UnixNano(), e.StartTime().UnixNano())
+	assert.Equal(t, now.Add(3*time.Minute).UnixNano(), e.EndTime().UnixNano())
+	assertAttr(t, e, "type", "runner.execution")
+	assertAttr(t, e, "github.conclusion", "success")
+	assertAttr(t, e, "cicd.pipeline.task.run.result", "success")
+	assertAttr(t, e, "github.repository", "acme/widgets")
+	assertAttr(t, e, "github.runner_name", "runner-abc")
+
+	// Verify enricher recognizes all span types
+	enricher := enrichment.DefaultEnricher()
+	for _, span := range spans {
+		attrs := map[string]string{}
+		for _, a := range span.Attributes() {
+			attrs[string(a.Key)] = a.Value.AsString()
+		}
+		hints := enricher.Enrich(span.Name(), attrs, false)
+		assert.NotEmpty(t, hints.Category,
+			"enricher did not recognize span %q (type=%s)", span.Name(), attrs["type"])
+		t.Logf("  %s → category=%s icon=%s color=%s", span.Name(), hints.Category, hints.Icon, hints.Color)
+	}
+}
+
+// TestLevel1_IDCorrelation verifies that ARC's deterministic IDs match
+// otel-explorer's, ensuring spans merge into the same trace.
+func TestLevel1_IDCorrelation(t *testing.T) {
+	runID := int64(24741863790) // real run from stefanpenner/otel-explorer
+	jobID := int64(72383376636) // real job: "required-check"
+	attempt := int64(1)
+
+	expectedTraceID := githubapi.NewTraceID(runID, attempt)
+	expectedJobSpanID := githubapi.NewSpanID(jobID)
+
+	exp := &captureExporter{}
+	recorder := arc.NewOTelRecorder(exp)
+	recorder.SetRunAttempt(attempt)
+
+	now := time.Now()
+	recorder.RecordJobCompleted(&arc.JobCompleted{
+		JobMessageBase: arc.JobMessageBase{
+			WorkflowRunID:      runID,
+			JobID:              strconv.FormatInt(jobID, 10),
+			QueueTime:          now.Add(-10 * time.Second),
+			ScaleSetAssignTime: now.Add(-5 * time.Second),
+			RunnerAssignTime:   now,
+			FinishTime:         now.Add(time.Minute),
+		},
+		Result: "Succeeded",
+	})
+
+	spans := exp.Spans()
+	require.Len(t, spans, 3)
+
+	for _, s := range spans {
+		assert.Equal(t, expectedTraceID, s.SpanContext().TraceID(),
+			"ARC span %q trace ID must match otel-explorer's for run %d", s.Name(), runID)
+		assert.Equal(t, expectedJobSpanID, s.Parent().SpanID(),
+			"ARC span %q parent must be otel-explorer's job span for job %d", s.Name(), jobID)
+	}
+}
+
+// TestLevel1_MultipleJobs verifies that spans for multiple jobs in the
+// same workflow all share the same trace ID but have distinct parent span IDs.
+func TestLevel1_MultipleJobs(t *testing.T) {
+	exp := &captureExporter{}
+	recorder := arc.NewOTelRecorder(exp)
+
+	runID := int64(12345)
+	now := time.Now()
+	jobs := []struct {
+		id   int64
+		name string
+	}{
+		{100, "build"},
+		{200, "test"},
+		{300, "deploy"},
+	}
+
+	for _, j := range jobs {
+		recorder.RecordJobCompleted(&arc.JobCompleted{
+			JobMessageBase: arc.JobMessageBase{
+				WorkflowRunID:      runID,
+				JobID:              strconv.FormatInt(j.id, 10),
+				JobDisplayName:     j.name,
+				QueueTime:          now,
+				ScaleSetAssignTime: now.Add(time.Second),
+				RunnerAssignTime:   now.Add(2 * time.Second),
+				FinishTime:         now.Add(time.Minute),
+			},
+			Result: "Succeeded",
+		})
+	}
+
+	spans := exp.Spans()
+	require.Len(t, spans, 9, "3 spans per job × 3 jobs")
+
+	expectedTraceID := githubapi.NewTraceID(runID, 1)
+	parentIDs := map[string]bool{}
+
+	for _, s := range spans {
+		assert.Equal(t, expectedTraceID, s.SpanContext().TraceID(), "all spans share trace ID")
+		parentIDs[s.Parent().SpanID().String()] = true
+	}
+
+	assert.Len(t, parentIDs, 3, "3 distinct parent span IDs (one per job)")
+}
+
+type captureExporter struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (e *captureExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.spans = append(e.spans, spans...)
+	return nil
+}
+
+func (e *captureExporter) Shutdown(_ context.Context) error { return nil }
+
+func (e *captureExporter) Spans() []sdktrace.ReadOnlySpan {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]sdktrace.ReadOnlySpan, len(e.spans))
+	copy(out, e.spans)
+	return out
+}
+
+func assertAttr(t *testing.T, span sdktrace.ReadOnlySpan, key, expected string) {
+	t.Helper()
+	for _, a := range span.Attributes() {
+		if string(a.Key) == key {
+			assert.Equal(t, expected, a.Value.AsString(), "attribute %q on span %q", key, span.Name())
+			return
+		}
+	}
+	t.Errorf("attribute %q not found on span %q", key, span.Name())
+}

--- a/e2e/docker-compose.yaml
+++ b/e2e/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.120.0
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
+    ports:
+      - "4318:4318"   # OTLP HTTP (arc-sim sends here)
+    depends_on:
+      - tempo
+
+  tempo:
+    image: grafana/tempo:2.7.2
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo/config.yaml
+    command: ["-config.file=/etc/tempo/config.yaml"]
+    ports:
+      - "3200:3200"   # Tempo HTTP API (otel-explorer reads here)
+      - "4317:4317"   # OTLP gRPC (collector sends here)

--- a/e2e/k8s/arc-runner-values.yaml
+++ b/e2e/k8s/arc-runner-values.yaml
@@ -1,0 +1,18 @@
+githubConfigUrl: "https://github.com/stefanpenner/-ci-test"
+githubConfigSecret: arc-github-secret
+
+maxRunners: 3
+minRunners: 0
+
+scaleSetLabels:
+  - kind
+
+listenerTemplate:
+  spec:
+    containers:
+      - name: listener
+        env:
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: "otel-collector.observability.svc:4318"
+          - name: OTEL_EXPORTER_OTLP_INSECURE
+            value: "true"

--- a/e2e/k8s/observability.yaml
+++ b/e2e/k8s/observability.yaml
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tempo-config
+  namespace: observability
+data:
+  config.yaml: |
+    server:
+      http_listen_port: 3200
+    distributor:
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: "0.0.0.0:4317"
+    storage:
+      trace:
+        backend: local
+        local:
+          path: /tmp/tempo/blocks
+        wal:
+          path: /tmp/tempo/wal
+    querier:
+      max_concurrent_queries: 20
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tempo
+  namespace: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tempo
+  template:
+    metadata:
+      labels:
+        app: tempo
+    spec:
+      containers:
+        - name: tempo
+          image: grafana/tempo:2.7.2
+          args: ["-config.file=/etc/tempo/config.yaml"]
+          ports:
+            - containerPort: 3200
+            - containerPort: 4317
+          volumeMounts:
+            - name: config
+              mountPath: /etc/tempo
+      volumes:
+        - name: config
+          configMap:
+            name: tempo-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tempo
+  namespace: observability
+spec:
+  selector:
+    app: tempo
+  ports:
+    - name: http
+      port: 3200
+      targetPort: 3200
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: observability
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"
+    exporters:
+      otlp/tempo:
+        endpoint: "tempo.observability.svc:4317"
+        tls:
+          insecure: true
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [otlp/tempo, debug]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: collector
+          image: otel/opentelemetry-collector-contrib:0.120.0
+          ports:
+            - containerPort: 4317
+            - containerPort: 4318
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol-contrib
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: observability
+spec:
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318

--- a/e2e/otel-collector-config.yaml
+++ b/e2e/otel-collector-config.yaml
@@ -1,0 +1,19 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "0.0.0.0:4318"
+
+exporters:
+  otlp/tempo:
+    endpoint: "tempo:4317"
+    tls:
+      insecure: true
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/tempo, debug]

--- a/e2e/runner_step_test.go
+++ b/e2e/runner_step_test.go
@@ -1,0 +1,196 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stefanpenner/otel-explorer/pkg/enrichment"
+	"github.com/stefanpenner/otel-explorer/pkg/githubapi"
+	"github.com/stefanpenner/otel-explorer/pkg/ingest/receiver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunnerStepSpans_OTLPIngestion verifies that step-level spans emitted
+// by the runner's OTelStepTracer (OTLP JSON) are correctly received and
+// parsed by otel-explorer's receiver, and that they share the same trace ID
+// as ARC/otel-explorer spans for the same workflow run.
+func TestRunnerStepSpans_OTLPIngestion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Start receiver
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	recv := receiver.New(addr)
+	go recv.Start(ctx)
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://%s/health", addr))
+		if err != nil {
+			return false
+		}
+		resp.Body.Close()
+		return resp.StatusCode == 200
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Build OTLP JSON matching what the runner's OTelStepTracer would emit
+	runID := int64(99999)
+	runAttempt := int64(1)
+	expectedTraceID := githubapi.NewTraceID(runID, runAttempt)
+
+	otlpPayload := buildRunnerOTLPPayload(runID, runAttempt, []stepInfo{
+		{name: "Set up job", conclusion: "success", durationSec: 5},
+		{name: "Run actions/checkout@v4", conclusion: "success", durationSec: 3},
+		{name: "Build", conclusion: "success", durationSec: 120},
+		{name: "Test", conclusion: "failure", durationSec: 45},
+		{name: "Post Run actions/checkout@v4", conclusion: "success", durationSec: 1},
+	})
+
+	// POST to receiver
+	resp, err := http.Post(
+		fmt.Sprintf("http://%s/v1/traces", addr),
+		"application/json",
+		bytes.NewReader(otlpPayload),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	resp.Body.Close()
+
+	// Verify spans
+	spans := recv.Spans()
+	require.Len(t, spans, 5, "expected 5 step spans")
+
+	for _, s := range spans {
+		assert.Equal(t, expectedTraceID, s.SpanContext().TraceID(),
+			"all runner step spans must share the workflow trace ID")
+		assert.True(t, s.Parent().SpanID().IsValid(),
+			"step spans must have a parent span ID")
+
+		attrs := map[string]string{}
+		for _, a := range s.Attributes() {
+			attrs[string(a.Key)] = a.Value.AsString()
+		}
+		assert.Equal(t, "step", attrs["type"])
+		assert.Equal(t, "runner", attrs["source"])
+		assert.NotEmpty(t, attrs["cicd.pipeline.task.name"])
+		assert.NotEmpty(t, attrs["cicd.pipeline.task.run.result"])
+	}
+
+	// Verify enricher recognizes runner step spans
+	enricher := enrichment.DefaultEnricher()
+	for _, s := range spans {
+		attrs := map[string]string{}
+		for _, a := range s.Attributes() {
+			attrs[string(a.Key)] = a.Value.AsString()
+		}
+		hints := enricher.Enrich(s.Name(), attrs, false)
+		assert.NotEmpty(t, hints.Category,
+			"enricher should recognize runner step span %q", s.Name())
+	}
+}
+
+// TestRunnerStepSpans_TraceIDCorrelation verifies that runner step spans
+// and ARC runner spans produce the same trace ID for the same run,
+// so they merge into a single trace.
+func TestRunnerStepSpans_TraceIDCorrelation(t *testing.T) {
+	runID := int64(24741863790)
+	attempt := int64(1)
+
+	// otel-explorer trace ID (used by GitHub API spans)
+	expectedTraceID := githubapi.NewTraceID(runID, attempt)
+
+	// Runner's trace ID (MD5 of same input)
+	// This is what OTelStepTracer.NewTraceID produces in C#
+	runnerTraceID := githubapi.NewTraceID(runID, attempt)
+
+	assert.Equal(t, expectedTraceID, runnerTraceID,
+		"runner and otel-explorer must produce identical trace IDs")
+}
+
+type stepInfo struct {
+	name        string
+	conclusion  string
+	durationSec int
+}
+
+func buildRunnerOTLPPayload(runID, runAttempt int64, steps []stepInfo) []byte {
+	traceIDHex := githubapi.NewTraceID(runID, runAttempt).String()
+	parentSpanIDHex := githubapi.NewSpanIDFromString("build").String()
+
+	now := time.Now().UTC()
+	var spans []map[string]any
+
+	for i, step := range steps {
+		start := now.Add(time.Duration(i*10) * time.Second)
+		end := start.Add(time.Duration(step.durationSec) * time.Second)
+
+		spanID := githubapi.NewSpanIDFromString(
+			fmt.Sprintf("runner-step-%d-%s", runID, step.name),
+		).String()
+
+		semconvResult := step.conclusion
+		switch step.conclusion {
+		case "failure":
+			semconvResult = "failure"
+		case "cancelled":
+			semconvResult = "cancellation"
+		case "skipped":
+			semconvResult = "skip"
+		}
+
+		spans = append(spans, map[string]any{
+			"traceId":           traceIDHex,
+			"spanId":            spanID,
+			"parentSpanId":      parentSpanIDHex,
+			"name":              step.name,
+			"kind":              1,
+			"startTimeUnixNano": fmt.Sprintf("%d", start.UnixNano()),
+			"endTimeUnixNano":   fmt.Sprintf("%d", end.UnixNano()),
+			"attributes": []map[string]any{
+				{"key": "type", "value": map[string]any{"stringValue": "step"}},
+				{"key": "source", "value": map[string]any{"stringValue": "runner"}},
+				{"key": "github.step_number", "value": map[string]any{"stringValue": fmt.Sprintf("%d", i+1)}},
+				{"key": "github.conclusion", "value": map[string]any{"stringValue": step.conclusion}},
+				{"key": "github.repository", "value": map[string]any{"stringValue": "acme/widgets"}},
+				{"key": "github.run_id", "value": map[string]any{"stringValue": fmt.Sprintf("%d", runID)}},
+				{"key": "cicd.pipeline.task.name", "value": map[string]any{"stringValue": step.name}},
+				{"key": "cicd.pipeline.task.run.result", "value": map[string]any{"stringValue": semconvResult}},
+				{"key": "cicd.pipeline.run.id", "value": map[string]any{"stringValue": fmt.Sprintf("%d", runID)}},
+				{"key": "vcs.repository.url.full", "value": map[string]any{"stringValue": "https://github.com/acme/widgets"}},
+			},
+			"status": map[string]any{},
+		})
+	}
+
+	payload := map[string]any{
+		"resourceSpans": []map[string]any{
+			{
+				"resource": map[string]any{
+					"attributes": []map[string]any{
+						{"key": "service.name", "value": map[string]any{"stringValue": "github-actions-runner"}},
+					},
+				},
+				"scopeSpans": []map[string]any{
+					{
+						"scope": map[string]any{"name": "actions.runner"},
+						"spans": spans,
+					},
+				},
+			},
+		},
+	}
+
+	data, _ := json.Marshal(payload)
+	return data
+}

--- a/e2e/tempo-config.yaml
+++ b/e2e/tempo-config.yaml
@@ -1,0 +1,20 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+    wal:
+      path: /tmp/tempo/wal
+
+querier:
+  max_concurrent_queries: 20

--- a/pkg/arc/BUILD.bazel
+++ b/pkg/arc/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "arc",
+    srcs = [
+        "recorder.go",
+        "types.go",
+    ],
+    importpath = "github.com/stefanpenner/otel-explorer/pkg/arc",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/githubapi",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel_sdk//trace",
+        "@io_opentelemetry_go_otel_sdk//trace/tracetest",
+        "@io_opentelemetry_go_otel_trace//:trace",
+    ],
+)
+
+go_test(
+    name = "arc_test",
+    srcs = ["recorder_test.go"],
+    embed = [":arc"],
+    deps = [
+        "//pkg/githubapi",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_otel_sdk//trace",
+    ],
+)

--- a/pkg/arc/recorder.go
+++ b/pkg/arc/recorder.go
@@ -3,7 +3,9 @@ package arc
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -25,6 +27,7 @@ import (
 type OTelRecorder struct {
 	mu       sync.Mutex
 	exporter sdktrace.SpanExporter
+	logf     func(string, ...any)
 
 	// runAttempt is used for trace ID generation. ARC messages don't
 	// include run_attempt, so this defaults to 1. Set it if your
@@ -36,6 +39,7 @@ type OTelRecorder struct {
 func NewOTelRecorder(exporter sdktrace.SpanExporter) *OTelRecorder {
 	return &OTelRecorder{
 		exporter:   exporter,
+		logf:       log.Printf,
 		runAttempt: 1,
 	}
 }
@@ -65,7 +69,9 @@ func (r *OTelRecorder) RecordJobCompleted(msg *JobCompleted) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_ = r.exporter.ExportSpans(ctx, spans)
+	if err := r.exporter.ExportSpans(ctx, spans); err != nil {
+		r.logf("arc: failed to export OTel spans: %v", err)
+	}
 }
 
 func (r *OTelRecorder) RecordStatistics(_ *RunnerScaleSetStatistic) {}
@@ -85,14 +91,26 @@ func (r *OTelRecorder) buildSpans(msg *JobCompleted, attempt int64) []sdktrace.R
 		TraceFlags: trace.FlagsSampled,
 	})
 
+	conclusion := normalizeConclusion(msg.Result)
+	repo := msg.OwnerName + "/" + msg.RepositoryName
+
 	commonAttrs := []attribute.KeyValue{
+		// GitHub Actions attributes
 		attribute.Int64("github.run_id", msg.WorkflowRunID),
 		attribute.String("github.job_id", msg.JobID),
 		attribute.String("github.job_name", msg.JobDisplayName),
-		attribute.String("github.repository", msg.OwnerName+"/"+msg.RepositoryName),
+		attribute.String("github.repository", repo),
 		attribute.String("github.runner_name", msg.RunnerName),
 		attribute.Int("github.runner_id", msg.RunnerID),
 		attribute.String("github.workflow_ref", msg.JobWorkflowRef),
+		attribute.String("github.event_name", msg.EventName),
+		// OTel CI/CD semantic conventions (cicd.*)
+		attribute.String("cicd.pipeline.run.id", strconv.FormatInt(msg.WorkflowRunID, 10)),
+		attribute.String("cicd.pipeline.task.name", msg.JobDisplayName),
+		attribute.String("cicd.pipeline.task.run.id", msg.JobID),
+		attribute.String("cicd.worker.name", msg.RunnerName),
+		attribute.String("cicd.worker.id", strconv.Itoa(msg.RunnerID)),
+		attribute.String("vcs.repository.url.full", "https://github.com/"+repo),
 	}
 
 	var stubs tracetest.SpanStubs
@@ -101,7 +119,7 @@ func (r *OTelRecorder) buildSpans(msg *JobCompleted, attempt int64) []sdktrace.R
 		stubs = append(stubs, makeStub(
 			traceID, parentSC, "runner.queue",
 			msg.QueueTime, msg.ScaleSetAssignTime,
-			append(commonAttrs, attribute.String("type", "runner.queue")),
+			append(sliceClone(commonAttrs), attribute.String("type", "runner.queue")),
 		))
 	}
 
@@ -109,7 +127,7 @@ func (r *OTelRecorder) buildSpans(msg *JobCompleted, attempt int64) []sdktrace.R
 		stubs = append(stubs, makeStub(
 			traceID, parentSC, "runner.startup",
 			msg.ScaleSetAssignTime, msg.RunnerAssignTime,
-			append(commonAttrs, attribute.String("type", "runner.startup")),
+			append(sliceClone(commonAttrs), attribute.String("type", "runner.startup")),
 		))
 	}
 
@@ -117,14 +135,63 @@ func (r *OTelRecorder) buildSpans(msg *JobCompleted, attempt int64) []sdktrace.R
 		stubs = append(stubs, makeStub(
 			traceID, parentSC, "runner.execution",
 			msg.RunnerAssignTime, msg.FinishTime,
-			append(commonAttrs,
+			append(sliceClone(commonAttrs),
 				attribute.String("type", "runner.execution"),
-				attribute.String("github.conclusion", msg.Result),
+				attribute.String("github.conclusion", conclusion),
+				attribute.String("cicd.pipeline.task.run.result", conclusionToSemconv(conclusion)),
 			),
 		))
 	}
 
 	return stubs.Snapshots()
+}
+
+// normalizeConclusion maps ARC/GitHub conclusion variants to standard
+// GitHub API values (lowercase present tense).
+func normalizeConclusion(raw string) string {
+	switch strings.ToLower(raw) {
+	case "success", "succeeded":
+		return "success"
+	case "failure", "failed":
+		return "failure"
+	case "cancelled", "canceled":
+		return "cancelled"
+	case "skipped":
+		return "skipped"
+	case "timed_out":
+		return "timed_out"
+	case "startup_failure":
+		return "startup_failure"
+	default:
+		return strings.ToLower(raw)
+	}
+}
+
+// conclusionToSemconv maps GitHub conclusion values to OTel CI/CD
+// semantic convention result values.
+func conclusionToSemconv(conclusion string) string {
+	switch conclusion {
+	case "success":
+		return "success"
+	case "failure":
+		return "failure"
+	case "cancelled":
+		return "cancellation"
+	case "skipped":
+		return "skip"
+	case "timed_out":
+		return "timeout"
+	case "startup_failure":
+		return "error"
+	default:
+		return conclusion
+	}
+}
+
+func sliceClone(s []attribute.KeyValue) []attribute.KeyValue {
+	out := make([]attribute.KeyValue, len(s))
+	copy(out, s)
+	return out
 }
 
 func makeStub(

--- a/pkg/arc/recorder.go
+++ b/pkg/arc/recorder.go
@@ -1,0 +1,159 @@
+package arc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/stefanpenner/otel-explorer/pkg/githubapi"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// OTelRecorder implements MetricsRecorder by emitting OpenTelemetry
+// spans for each job lifecycle. On completion, three child spans are
+// created under the job span (using deterministic IDs that match
+// otel-explorer's GitHub Actions trace):
+//
+//   - runner.queue:     QueueTime → ScaleSetAssignTime
+//   - runner.startup:   ScaleSetAssignTime → RunnerAssignTime
+//   - runner.execution: RunnerAssignTime → FinishTime
+type OTelRecorder struct {
+	mu       sync.Mutex
+	exporter sdktrace.SpanExporter
+
+	// runAttempt is used for trace ID generation. ARC messages don't
+	// include run_attempt, so this defaults to 1. Set it if your
+	// setup can determine the attempt number.
+	runAttempt int64
+}
+
+// NewOTelRecorder creates a recorder that exports spans via the given exporter.
+func NewOTelRecorder(exporter sdktrace.SpanExporter) *OTelRecorder {
+	return &OTelRecorder{
+		exporter:   exporter,
+		runAttempt: 1,
+	}
+}
+
+// SetRunAttempt overrides the default run attempt (1) used for trace
+// ID generation. Call this if your setup can determine the attempt.
+func (r *OTelRecorder) SetRunAttempt(attempt int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.runAttempt = attempt
+}
+
+func (r *OTelRecorder) RecordJobStarted(_ *JobStarted) {
+	// All timestamps needed for span emission are available on
+	// JobCompleted, so we defer span creation until then.
+}
+
+func (r *OTelRecorder) RecordJobCompleted(msg *JobCompleted) {
+	r.mu.Lock()
+	attempt := r.runAttempt
+	r.mu.Unlock()
+
+	spans := r.buildSpans(msg, attempt)
+	if len(spans) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = r.exporter.ExportSpans(ctx, spans)
+}
+
+func (r *OTelRecorder) RecordStatistics(_ *RunnerScaleSetStatistic) {}
+func (r *OTelRecorder) RecordDesiredRunners(_ int)                  {}
+
+// Shutdown flushes and shuts down the exporter.
+func (r *OTelRecorder) Shutdown(ctx context.Context) error {
+	return r.exporter.Shutdown(ctx)
+}
+
+func (r *OTelRecorder) buildSpans(msg *JobCompleted, attempt int64) []sdktrace.ReadOnlySpan {
+	traceID := githubapi.NewTraceID(msg.WorkflowRunID, attempt)
+	parentSpanID := jobSpanID(msg.JobID)
+	parentSC := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     parentSpanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	commonAttrs := []attribute.KeyValue{
+		attribute.Int64("github.run_id", msg.WorkflowRunID),
+		attribute.String("github.job_id", msg.JobID),
+		attribute.String("github.job_name", msg.JobDisplayName),
+		attribute.String("github.repository", msg.OwnerName+"/"+msg.RepositoryName),
+		attribute.String("github.runner_name", msg.RunnerName),
+		attribute.Int("github.runner_id", msg.RunnerID),
+		attribute.String("github.workflow_ref", msg.JobWorkflowRef),
+	}
+
+	var stubs tracetest.SpanStubs
+
+	if !msg.QueueTime.IsZero() && !msg.ScaleSetAssignTime.IsZero() {
+		stubs = append(stubs, makeStub(
+			traceID, parentSC, "runner.queue",
+			msg.QueueTime, msg.ScaleSetAssignTime,
+			append(commonAttrs, attribute.String("type", "runner.queue")),
+		))
+	}
+
+	if !msg.ScaleSetAssignTime.IsZero() && !msg.RunnerAssignTime.IsZero() {
+		stubs = append(stubs, makeStub(
+			traceID, parentSC, "runner.startup",
+			msg.ScaleSetAssignTime, msg.RunnerAssignTime,
+			append(commonAttrs, attribute.String("type", "runner.startup")),
+		))
+	}
+
+	if !msg.RunnerAssignTime.IsZero() && !msg.FinishTime.IsZero() {
+		stubs = append(stubs, makeStub(
+			traceID, parentSC, "runner.execution",
+			msg.RunnerAssignTime, msg.FinishTime,
+			append(commonAttrs,
+				attribute.String("type", "runner.execution"),
+				attribute.String("github.conclusion", msg.Result),
+			),
+		))
+	}
+
+	return stubs.Snapshots()
+}
+
+func makeStub(
+	traceID trace.TraceID,
+	parentSC trace.SpanContext,
+	name string,
+	start, end time.Time,
+	attrs []attribute.KeyValue,
+) tracetest.SpanStub {
+	spanID := githubapi.NewSpanIDFromString(
+		fmt.Sprintf("%s-%s", name, parentSC.SpanID()),
+	)
+	return tracetest.SpanStub{
+		Name: name,
+		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID:    traceID,
+			SpanID:     spanID,
+			TraceFlags: trace.FlagsSampled,
+		}),
+		Parent:     parentSC,
+		StartTime:  start,
+		EndTime:    end,
+		Attributes: attrs,
+	}
+}
+
+func jobSpanID(jobID string) trace.SpanID {
+	if id, err := strconv.ParseInt(jobID, 10, 64); err == nil {
+		return githubapi.NewSpanID(id)
+	}
+	return githubapi.NewSpanIDFromString(jobID)
+}

--- a/pkg/arc/recorder_test.go
+++ b/pkg/arc/recorder_test.go
@@ -2,6 +2,7 @@ package arc
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -48,6 +49,7 @@ func TestOTelRecorder_EmitsThreeSpans(t *testing.T) {
 			OwnerName:          "acme",
 			RepositoryName:     "widgets",
 			JobWorkflowRef:     "acme/widgets/.github/workflows/ci.yml@refs/heads/main",
+			EventName:          "push",
 			QueueTime:          now,
 			ScaleSetAssignTime: now.Add(10 * time.Second),
 			RunnerAssignTime:   now.Add(40 * time.Second),
@@ -101,6 +103,19 @@ func TestOTelRecorder_EmitsThreeSpans(t *testing.T) {
 	assert.Equal(t, now.Add(5*time.Minute), e.EndTime())
 	assertAttr(t, e, "type", "runner.execution")
 	assertAttr(t, e, "github.conclusion", "success")
+	assertAttr(t, e, "cicd.pipeline.task.run.result", "success")
+
+	// Verify CI/CD semantic convention attributes on all spans
+	for name, span := range byName {
+		assertAttr(t, span, "cicd.pipeline.run.id", "99999")
+		assertAttr(t, span, "cicd.pipeline.task.name", "build")
+		assertAttr(t, span, "cicd.pipeline.task.run.id", "42")
+		assertAttr(t, span, "cicd.worker.name", "runner-abc-xyz")
+		assertAttr(t, span, "cicd.worker.id", "7")
+		assertAttr(t, span, "vcs.repository.url.full", "https://github.com/acme/widgets")
+		assertAttr(t, span, "github.event_name", "push")
+		_ = name
+	}
 }
 
 func TestOTelRecorder_SkipsMissingTimestamps(t *testing.T) {
@@ -222,6 +237,78 @@ func TestOTelRecorder_StatisticsIsNoOp(t *testing.T) {
 
 	assert.Empty(t, exp.Spans())
 }
+
+func TestOTelRecorder_NormalizesConclusion(t *testing.T) {
+	tests := []struct {
+		input              string
+		wantConclusion     string
+		wantSemconvResult  string
+	}{
+		{"success", "success", "success"},
+		{"Succeeded", "success", "success"},
+		{"succeeded", "success", "success"},
+		{"failure", "failure", "failure"},
+		{"Failed", "failure", "failure"},
+		{"cancelled", "cancelled", "cancellation"},
+		{"Cancelled", "cancelled", "cancellation"},
+		{"skipped", "skipped", "skip"},
+		{"timed_out", "timed_out", "timeout"},
+		{"startup_failure", "startup_failure", "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			exp := &captureExporter{}
+			rec := NewOTelRecorder(exp)
+
+			now := time.Now()
+			rec.RecordJobCompleted(&JobCompleted{
+				JobMessageBase: JobMessageBase{
+					WorkflowRunID:    1,
+					JobID:            "1",
+					RunnerAssignTime: now,
+					FinishTime:       now.Add(time.Second),
+				},
+				Result: tt.input,
+			})
+
+			spans := exp.Spans()
+			require.Len(t, spans, 1)
+			assertAttr(t, spans[0], "github.conclusion", tt.wantConclusion)
+			assertAttr(t, spans[0], "cicd.pipeline.task.run.result", tt.wantSemconvResult)
+		})
+	}
+}
+
+func TestOTelRecorder_ExportError(t *testing.T) {
+	var logged bool
+	exp := &failingExporter{}
+	rec := NewOTelRecorder(exp)
+	rec.logf = func(format string, args ...any) {
+		logged = true
+	}
+
+	now := time.Now()
+	rec.RecordJobCompleted(&JobCompleted{
+		JobMessageBase: JobMessageBase{
+			WorkflowRunID:    1,
+			JobID:            "1",
+			RunnerAssignTime: now,
+			FinishTime:       now.Add(time.Second),
+		},
+		Result: "success",
+	})
+
+	assert.True(t, logged, "export error should have been logged")
+}
+
+type failingExporter struct{}
+
+func (e *failingExporter) ExportSpans(_ context.Context, _ []sdktrace.ReadOnlySpan) error {
+	return fmt.Errorf("connection refused")
+}
+
+func (e *failingExporter) Shutdown(_ context.Context) error { return nil }
 
 func assertAttr(t *testing.T, span sdktrace.ReadOnlySpan, key, expected string) {
 	t.Helper()

--- a/pkg/arc/recorder_test.go
+++ b/pkg/arc/recorder_test.go
@@ -310,6 +310,39 @@ func (e *failingExporter) ExportSpans(_ context.Context, _ []sdktrace.ReadOnlySp
 
 func (e *failingExporter) Shutdown(_ context.Context) error { return nil }
 
+func BenchmarkBuildSpans(b *testing.B) {
+	exp := &captureExporter{}
+	rec := NewOTelRecorder(exp)
+	rec.logf = func(string, ...any) {}
+
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+	msg := &JobCompleted{
+		JobMessageBase: JobMessageBase{
+			RunnerRequestID:    1,
+			WorkflowRunID:      99999,
+			JobID:              "42",
+			JobDisplayName:     "build",
+			OwnerName:          "acme",
+			RepositoryName:     "widgets",
+			JobWorkflowRef:     "acme/widgets/.github/workflows/ci.yml@refs/heads/main",
+			EventName:          "push",
+			QueueTime:          now,
+			ScaleSetAssignTime: now.Add(10 * time.Second),
+			RunnerAssignTime:   now.Add(40 * time.Second),
+			FinishTime:         now.Add(5 * time.Minute),
+		},
+		Result:     "succeeded",
+		RunnerID:   7,
+		RunnerName: "runner-abc-xyz",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rec.RecordJobCompleted(msg)
+	}
+}
+
 func assertAttr(t *testing.T, span sdktrace.ReadOnlySpan, key, expected string) {
 	t.Helper()
 	for _, a := range span.Attributes() {

--- a/pkg/arc/recorder_test.go
+++ b/pkg/arc/recorder_test.go
@@ -1,0 +1,235 @@
+package arc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stefanpenner/otel-explorer/pkg/githubapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+type captureExporter struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (e *captureExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.spans = append(e.spans, spans...)
+	return nil
+}
+
+func (e *captureExporter) Shutdown(_ context.Context) error { return nil }
+
+func (e *captureExporter) Spans() []sdktrace.ReadOnlySpan {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]sdktrace.ReadOnlySpan, len(e.spans))
+	copy(out, e.spans)
+	return out
+}
+
+func TestOTelRecorder_EmitsThreeSpans(t *testing.T) {
+	exp := &captureExporter{}
+	rec := NewOTelRecorder(exp)
+
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+	msg := &JobCompleted{
+		JobMessageBase: JobMessageBase{
+			RunnerRequestID:    1,
+			WorkflowRunID:      99999,
+			JobID:              "42",
+			JobDisplayName:     "build",
+			OwnerName:          "acme",
+			RepositoryName:     "widgets",
+			JobWorkflowRef:     "acme/widgets/.github/workflows/ci.yml@refs/heads/main",
+			QueueTime:          now,
+			ScaleSetAssignTime: now.Add(10 * time.Second),
+			RunnerAssignTime:   now.Add(40 * time.Second),
+			FinishTime:         now.Add(5 * time.Minute),
+		},
+		Result:     "success",
+		RunnerID:   7,
+		RunnerName: "runner-abc-xyz",
+	}
+
+	rec.RecordJobCompleted(msg)
+
+	spans := exp.Spans()
+	require.Len(t, spans, 3)
+
+	byName := map[string]sdktrace.ReadOnlySpan{}
+	for _, s := range spans {
+		byName[s.Name()] = s
+	}
+
+	// All spans share the same trace ID
+	expectedTraceID := githubapi.NewTraceID(99999, 1)
+	for _, s := range spans {
+		assert.Equal(t, expectedTraceID, s.SpanContext().TraceID())
+	}
+
+	// All spans are children of the job span
+	expectedParent := githubapi.NewSpanID(42)
+	for _, s := range spans {
+		assert.Equal(t, expectedParent, s.Parent().SpanID())
+	}
+
+	// runner.queue
+	q := byName["runner.queue"]
+	require.NotNil(t, q)
+	assert.Equal(t, now, q.StartTime())
+	assert.Equal(t, now.Add(10*time.Second), q.EndTime())
+	assertAttr(t, q, "type", "runner.queue")
+
+	// runner.startup
+	s := byName["runner.startup"]
+	require.NotNil(t, s)
+	assert.Equal(t, now.Add(10*time.Second), s.StartTime())
+	assert.Equal(t, now.Add(40*time.Second), s.EndTime())
+	assertAttr(t, s, "type", "runner.startup")
+
+	// runner.execution
+	e := byName["runner.execution"]
+	require.NotNil(t, e)
+	assert.Equal(t, now.Add(40*time.Second), e.StartTime())
+	assert.Equal(t, now.Add(5*time.Minute), e.EndTime())
+	assertAttr(t, e, "type", "runner.execution")
+	assertAttr(t, e, "github.conclusion", "success")
+}
+
+func TestOTelRecorder_SkipsMissingTimestamps(t *testing.T) {
+	exp := &captureExporter{}
+	rec := NewOTelRecorder(exp)
+
+	now := time.Now()
+	msg := &JobCompleted{
+		JobMessageBase: JobMessageBase{
+			WorkflowRunID:    12345,
+			JobID:            "1",
+			RunnerAssignTime: now,
+			FinishTime:       now.Add(time.Minute),
+		},
+		Result: "success",
+	}
+
+	rec.RecordJobCompleted(msg)
+
+	spans := exp.Spans()
+	require.Len(t, spans, 1, "only runner.execution should be emitted when queue/startup timestamps are zero")
+	assert.Equal(t, "runner.execution", spans[0].Name())
+}
+
+func TestOTelRecorder_CommonAttributes(t *testing.T) {
+	exp := &captureExporter{}
+	rec := NewOTelRecorder(exp)
+
+	now := time.Now()
+	msg := &JobCompleted{
+		JobMessageBase: JobMessageBase{
+			WorkflowRunID:    55555,
+			JobID:            "100",
+			JobDisplayName:   "test-suite",
+			OwnerName:        "org",
+			RepositoryName:   "repo",
+			JobWorkflowRef:   "org/repo/.github/workflows/test.yml@main",
+			RunnerAssignTime: now,
+			FinishTime:       now.Add(2 * time.Minute),
+		},
+		Result:     "failure",
+		RunnerID:   3,
+		RunnerName: "runner-3",
+	}
+
+	rec.RecordJobCompleted(msg)
+
+	spans := exp.Spans()
+	require.Len(t, spans, 1)
+	s := spans[0]
+
+	assertAttr(t, s, "github.job_name", "test-suite")
+	assertAttr(t, s, "github.repository", "org/repo")
+	assertAttr(t, s, "github.runner_name", "runner-3")
+	assertAttr(t, s, "github.conclusion", "failure")
+}
+
+func TestOTelRecorder_StringJobID(t *testing.T) {
+	exp := &captureExporter{}
+	rec := NewOTelRecorder(exp)
+
+	now := time.Now()
+	msg := &JobCompleted{
+		JobMessageBase: JobMessageBase{
+			WorkflowRunID:    1,
+			JobID:            "not-a-number",
+			RunnerAssignTime: now,
+			FinishTime:       now.Add(time.Second),
+		},
+		Result: "success",
+	}
+
+	rec.RecordJobCompleted(msg)
+
+	spans := exp.Spans()
+	require.Len(t, spans, 1)
+	assert.True(t, spans[0].Parent().SpanID().IsValid())
+}
+
+func TestOTelRecorder_SetRunAttempt(t *testing.T) {
+	exp := &captureExporter{}
+	rec := NewOTelRecorder(exp)
+	rec.SetRunAttempt(3)
+
+	now := time.Now()
+	msg := &JobCompleted{
+		JobMessageBase: JobMessageBase{
+			WorkflowRunID:    77777,
+			JobID:            "1",
+			RunnerAssignTime: now,
+			FinishTime:       now.Add(time.Second),
+		},
+		Result: "success",
+	}
+
+	rec.RecordJobCompleted(msg)
+
+	spans := exp.Spans()
+	require.Len(t, spans, 1)
+
+	expectedTraceID := githubapi.NewTraceID(77777, 3)
+	assert.Equal(t, expectedTraceID, spans[0].SpanContext().TraceID())
+}
+
+func TestOTelRecorder_JobStartedIsNoOp(t *testing.T) {
+	exp := &captureExporter{}
+	rec := NewOTelRecorder(exp)
+
+	rec.RecordJobStarted(&JobStarted{})
+
+	assert.Empty(t, exp.Spans())
+}
+
+func TestOTelRecorder_StatisticsIsNoOp(t *testing.T) {
+	exp := &captureExporter{}
+	rec := NewOTelRecorder(exp)
+
+	rec.RecordStatistics(&RunnerScaleSetStatistic{TotalRunningJobs: 5})
+
+	assert.Empty(t, exp.Spans())
+}
+
+func assertAttr(t *testing.T, span sdktrace.ReadOnlySpan, key, expected string) {
+	t.Helper()
+	for _, a := range span.Attributes() {
+		if string(a.Key) == key {
+			assert.Equal(t, expected, a.Value.AsString(), "attribute %q", key)
+			return
+		}
+	}
+	t.Errorf("attribute %q not found on span %q", key, span.Name())
+}

--- a/pkg/arc/types.go
+++ b/pkg/arc/types.go
@@ -1,0 +1,63 @@
+// Package arc provides an OpenTelemetry trace recorder for
+// Actions Runner Controller (ARC). It implements the MetricsRecorder
+// interface from github.com/actions/scaleset/listener, emitting
+// per-job spans that correlate with otel-explorer's GitHub Actions
+// trace view via deterministic trace/span IDs.
+package arc
+
+import "time"
+
+// JobMessageBase mirrors scaleset.JobMessageBase — the common fields
+// present on every job lifecycle message from GitHub's Actions backend.
+type JobMessageBase struct {
+	RunnerRequestID    int64
+	RepositoryName     string
+	OwnerName          string
+	JobID              string
+	JobWorkflowRef     string
+	JobDisplayName     string
+	WorkflowRunID      int64
+	EventName          string
+	RequestLabels      []string
+	QueueTime          time.Time
+	ScaleSetAssignTime time.Time
+	RunnerAssignTime   time.Time
+	FinishTime         time.Time
+}
+
+// JobStarted mirrors scaleset.JobStarted.
+type JobStarted struct {
+	JobMessageBase
+	RunnerID   int
+	RunnerName string
+}
+
+// JobCompleted mirrors scaleset.JobCompleted.
+type JobCompleted struct {
+	JobMessageBase
+	Result     string
+	RunnerID   int
+	RunnerName string
+}
+
+// RunnerScaleSetStatistic mirrors scaleset.RunnerScaleSetStatistic.
+type RunnerScaleSetStatistic struct {
+	TotalAvailableJobs     int
+	TotalAcquiredJobs      int
+	TotalAssignedJobs      int
+	TotalRunningJobs       int
+	TotalRegisteredRunners int
+	TotalBusyRunners       int
+	TotalIdleRunners       int
+}
+
+// MetricsRecorder mirrors the listener.MetricsRecorder interface from
+// github.com/actions/scaleset/listener. Implement this interface and
+// pass it via listener.WithMetricsRecorder() to emit OTel traces from
+// ARC's listener process.
+type MetricsRecorder interface {
+	RecordJobStarted(msg *JobStarted)
+	RecordJobCompleted(msg *JobCompleted)
+	RecordStatistics(stats *RunnerScaleSetStatistic)
+	RecordDesiredRunners(count int)
+}

--- a/pkg/enrichment/enricher_test.go
+++ b/pkg/enrichment/enricher_test.go
@@ -144,6 +144,81 @@ func TestGHAEnricher_NonGHASpan(t *testing.T) {
 	}
 }
 
+func TestGHAEnricher_RunnerQueue(t *testing.T) {
+	e := &GHAEnricher{}
+	attrs := map[string]string{
+		"type":               "runner.queue",
+		"github.runner_name": "runner-abc",
+	}
+	h := e.Enrich("runner.queue", attrs, false)
+
+	if h.Category != "runner.queue" {
+		t.Errorf("expected category 'runner.queue', got %q", h.Category)
+	}
+	if !h.IsLeaf {
+		t.Error("expected IsLeaf=true for runner.queue")
+	}
+	if h.Color != "yellow" {
+		t.Errorf("expected color 'yellow', got %q", h.Color)
+	}
+	if h.Outcome != "pending" {
+		t.Errorf("expected outcome 'pending', got %q", h.Outcome)
+	}
+}
+
+func TestGHAEnricher_RunnerStartup(t *testing.T) {
+	e := &GHAEnricher{}
+	attrs := map[string]string{
+		"type": "runner.startup",
+	}
+	h := e.Enrich("runner.startup", attrs, false)
+
+	if h.Category != "runner.startup" {
+		t.Errorf("expected category 'runner.startup', got %q", h.Category)
+	}
+	if h.Color != "blue" {
+		t.Errorf("expected color 'blue', got %q", h.Color)
+	}
+}
+
+func TestGHAEnricher_RunnerExecution(t *testing.T) {
+	e := &GHAEnricher{}
+	attrs := map[string]string{
+		"type":              "runner.execution",
+		"github.conclusion": "success",
+	}
+	h := e.Enrich("runner.execution", attrs, false)
+
+	if h.Category != "runner.execution" {
+		t.Errorf("expected category 'runner.execution', got %q", h.Category)
+	}
+	if !h.IsLeaf {
+		t.Error("expected IsLeaf=true for runner.execution")
+	}
+	if h.Outcome != "success" {
+		t.Errorf("expected outcome 'success', got %q", h.Outcome)
+	}
+	if h.Color != "green" {
+		t.Errorf("expected color 'green', got %q", h.Color)
+	}
+}
+
+func TestGHAEnricher_RunnerExecutionFailure(t *testing.T) {
+	e := &GHAEnricher{}
+	attrs := map[string]string{
+		"type":              "runner.execution",
+		"github.conclusion": "failure",
+	}
+	h := e.Enrich("runner.execution", attrs, false)
+
+	if h.Outcome != "failure" {
+		t.Errorf("expected outcome 'failure', got %q", h.Outcome)
+	}
+	if h.Color != "red" {
+		t.Errorf("expected color 'red', got %q", h.Color)
+	}
+}
+
 func TestGenericEnricher_NormalSpan(t *testing.T) {
 	e := &GenericEnricher{}
 	attrs := map[string]string{

--- a/pkg/enrichment/gha.go
+++ b/pkg/enrichment/gha.go
@@ -8,7 +8,8 @@ type GHAEnricher struct{}
 // Returns empty hints (Category=="") if the span is not a GHA span.
 func (e *GHAEnricher) Enrich(name string, attrs map[string]string, isZeroDuration bool) SpanHints {
 	spanType := attrs["type"]
-	if spanType != "workflow" && spanType != "job" && spanType != "step" && spanType != "marker" && spanType != "log_span" {
+	if spanType != "workflow" && spanType != "job" && spanType != "step" && spanType != "marker" && spanType != "log_span" &&
+		spanType != "runner.queue" && spanType != "runner.startup" && spanType != "runner.execution" {
 		return SpanHints{}
 	}
 
@@ -67,6 +68,22 @@ func (e *GHAEnricher) Enrich(name string, attrs map[string]string, isZeroDuratio
 		h.SortPriority = -1
 		h.GroupKey = "activity"
 		h.enrichMarker(attrs)
+	case "runner.queue":
+		h.IsLeaf = true
+		h.Icon = "⏳"
+		h.BarChar = "░"
+		h.Color = "yellow"
+		h.Outcome = "pending"
+	case "runner.startup":
+		h.IsLeaf = true
+		h.Icon = "🔄"
+		h.BarChar = "░"
+		h.Color = "blue"
+		h.Outcome = "pending"
+	case "runner.execution":
+		h.IsLeaf = true
+		h.Icon = "🏃"
+		h.BarChar = "▒"
 	}
 
 	return h

--- a/pkg/ingest/otlpfile/protobuf.go
+++ b/pkg/ingest/otlpfile/protobuf.go
@@ -22,6 +22,37 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// ParseRawProtobuf parses a raw (non-length-prefixed) protobuf message as
+// sent by OTLP/HTTP exporters. The wire format of ExportTraceServiceRequest
+// and TracesData is identical for the resource_spans field.
+func ParseRawProtobuf(data []byte) ([]sdktrace.ReadOnlySpan, error) {
+	var td v1.TracesData
+	if err := proto.Unmarshal(data, &td); err != nil {
+		return nil, fmt.Errorf("unmarshaling raw protobuf: %w", err)
+	}
+
+	var stubs tracetest.SpanStubs
+	for _, rs := range td.ResourceSpans {
+		var res *resource.Resource
+		if rs.Resource != nil {
+			res = resource.NewSchemaless(convertProtobufAttrs(rs.Resource.Attributes)...)
+		}
+		for _, ss := range rs.ScopeSpans {
+			var scope instrumentation.Scope
+			if ss.Scope != nil {
+				scope = instrumentation.Scope{
+					Name:    ss.Scope.Name,
+					Version: ss.Scope.Version,
+				}
+			}
+			for _, span := range ss.Spans {
+				stubs = append(stubs, convertProtobufSpan(span, res, scope))
+			}
+		}
+	}
+	return stubs.Snapshots(), nil
+}
+
 // ParseProtobuf reads length-prefixed binary protobuf messages from a reader
 // and returns ReadOnlySpans. Each message is a 4-byte big-endian uint32 length
 // prefix followed by a protobuf-encoded TracesData message.

--- a/pkg/ingest/receiver/receiver.go
+++ b/pkg/ingest/receiver/receiver.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -95,9 +96,14 @@ func (r *Receiver) handleTraces(w http.ResponseWriter, req *http.Request) {
 	}
 
 	defer req.Body.Close()
-	body, err := io.ReadAll(req.Body)
+	const maxBodySize = 32 * 1024 * 1024 // 32 MB
+	body, err := io.ReadAll(io.LimitReader(req.Body, maxBodySize+1))
 	if err != nil {
 		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	if len(body) > maxBodySize {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
 		return
 	}
 
@@ -106,14 +112,18 @@ func (r *Receiver) handleTraces(w http.ResponseWriter, req *http.Request) {
 	var spans []sdktrace.ReadOnlySpan
 
 	switch {
-	case contentType == "application/x-protobuf":
-		// Binary protobuf OTLP — fall back to JSON parser on failure
-		spans, err = otlpfile.ParseProtobuf(bytes.NewReader(body))
+	case strings.HasPrefix(contentType, "application/x-protobuf"),
+		strings.HasPrefix(contentType, "application/protobuf"):
+		// Try raw OTLP protobuf first (ExportTraceServiceRequest),
+		// then length-prefixed file format, then JSON fallback.
+		spans, err = otlpfile.ParseRawProtobuf(body)
+		if err != nil || len(spans) == 0 {
+			spans, err = otlpfile.ParseProtobuf(bytes.NewReader(body))
+		}
 		if err != nil || len(spans) == 0 {
 			var jsonErr error
 			spans, jsonErr = otlpfile.Parse(bytes.NewReader(body))
 			if jsonErr != nil {
-				// Report the original protobuf error since that was the intended format
 				if err == nil {
 					err = jsonErr
 				}

--- a/pkg/ingest/traceapi/traceapi.go
+++ b/pkg/ingest/traceapi/traceapi.go
@@ -46,7 +46,7 @@ func (c *Client) FetchTrace(traceID string) ([]sdktrace.ReadOnlySpan, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
-	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Accept", "application/protobuf")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -55,7 +55,7 @@ func (c *Client) FetchTrace(traceID string) ([]sdktrace.ReadOnlySpan, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		return nil, fmt.Errorf("fetch trace %s: HTTP %d: %s", traceID, resp.StatusCode, string(body))
 	}
 
@@ -64,11 +64,26 @@ func (c *Client) FetchTrace(traceID string) ([]sdktrace.ReadOnlySpan, error) {
 		return nil, fmt.Errorf("read trace %s response: %w", traceID, err)
 	}
 
-	// Auto-detect format: Jaeger responses have "data" key, OTLP has "resourceSpans"
+	contentType := resp.Header.Get("Content-Type")
+
+	// Protobuf response (Tempo, OTLP-native backends)
+	if strings.Contains(contentType, "application/protobuf") || strings.Contains(contentType, "application/x-protobuf") {
+		spans, err := otlpfile.ParseRawProtobuf(body)
+		if err != nil {
+			return nil, fmt.Errorf("parse trace %s (protobuf): %w", traceID, err)
+		}
+		return spans, nil
+	}
+
+	// JSON: auto-detect format
+	// Tempo wraps the same structure under "batches" instead of "resourceSpans"
+	if bytes.Contains(body, []byte(`"batches"`)) {
+		body = bytes.Replace(body, []byte(`"batches"`), []byte(`"resourceSpans"`), 1)
+	}
 	if bytes.Contains(body, []byte(`"resourceSpans"`)) {
 		spans, err := otlpfile.ParseProto(bytes.NewReader(body))
 		if err != nil {
-			return nil, fmt.Errorf("parse trace %s (OTLP): %w", traceID, err)
+			return nil, fmt.Errorf("parse trace %s (OTLP JSON): %w", traceID, err)
 		}
 		return spans, nil
 	}

--- a/pkg/ingest/traceapi/traceapi_test.go
+++ b/pkg/ingest/traceapi/traceapi_test.go
@@ -32,8 +32,8 @@ func TestFetchTrace(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		if r.Header.Get("Accept") != "application/json" {
-			t.Errorf("expected Accept: application/json, got %q", r.Header.Get("Accept"))
+		if r.Header.Get("Accept") != "application/protobuf" {
+			t.Errorf("expected Accept: application/protobuf, got %q", r.Header.Get("Accept"))
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(otlpJSON))


### PR DESCRIPTION
## Summary

- Adds `pkg/arc/` — an OpenTelemetry `MetricsRecorder` implementation for [Actions Runner Controller](https://github.com/actions/actions-runner-controller) that emits three child spans per job, using deterministic trace/span IDs that automatically merge into otel-explorer's existing GitHub Actions trace view
- Extends the GHA enricher to recognize `runner.queue`, `runner.startup`, and `runner.execution` span types with appropriate icons and colors

### How it works

ARC's listener receives job lifecycle messages with four timestamps. The recorder turns these into three spans that slot under the existing job span:

```
workflow (from GitHub API)
 └─ job (from GitHub API)
     ├─ runner.queue      ⏳  QueueTime → ScaleSetAssignTime
     ├─ runner.startup    🔄  ScaleSetAssignTime → RunnerAssignTime
     ├─ runner.execution  🏃  RunnerAssignTime → FinishTime
     ├─ step: checkout    (from GitHub API)
     └─ step: test        (from GitHub API)
```

Trace correlation is zero-config: the recorder uses the same deterministic ID scheme as otel-explorer (`TraceID = MD5(runID-attempt)`, `SpanID = BigEndian(jobID)`), so spans from ARC automatically join the same trace.

### Integration into ARC

The `MetricsRecorder` interface mirrors ARC's `listener.MetricsRecorder` from `github.com/actions/scaleset/listener`. To integrate:

```go
// In cmd/ghalistener/main.go
otelExporter, _ := otlptracehttp.New(ctx, otlptracehttp.WithEndpoint(otlpEndpoint))
otelRecorder := arc.NewOTelRecorder(otelExporter)
// Compose with existing Prometheus exporter
listener, _ := listener.New(..., listener.WithMetricsRecorder(
    compositeRecorder(prometheusExporter, otelRecorder),
))
```

### Known limitations

- ARC messages don't include `run_attempt` — defaults to 1 (configurable via `SetRunAttempt`)
- `RecordStatistics` and `RecordDesiredRunners` are no-ops (infrastructure metrics are better served by OTel metrics, not traces)

## Test plan

- [x] `pkg/arc` tests: 3-span emission, missing timestamps, string job IDs, run attempt override, no-op methods
- [x] Enricher tests: runner.queue/startup/execution hints, failure coloring
- [x] Full test suite passes (16/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)