### PR TITLE
Harden decision-stack verify (duals + regen no-diff)

### DIFF
--- a/scripts/verify-decision-wires.sh
+++ b/scripts/verify-decision-wires.sh
@@ -36,6 +36,17 @@ gen_pkgs=(
   "pkg/analyzer/spantreespec/spec.go"
 )
 
+# Dual tests that pin production gates to generated Can*/actions.
+dual_tests=(
+  "pkg/tui/results/tuireload_decision_dual_test.go"
+  "pkg/githubapi/rate_limit_decision_dual_test.go"
+  "pkg/analyzer/clamp_decision_dual_test.go"
+  "pkg/store/sync_bounds_decision_dual_test.go"
+  "pkg/analyzer/gha_lifecycle_decision_dual_test.go"
+  "pkg/logparse/loggroups_decision_dual_test.go"
+  "pkg/analyzer/spantree_decision_dual_test.go"
+)
+
 # True if $sym appears in a non-test, non-*spec production .go under $dir.
 # Uses find+grep so CI does not need ripgrep.
 has_prod_symbol() {
@@ -81,6 +92,35 @@ for row in "${wires[@]}"; do
     fail=1
   fi
 done
+
+echo "--- dual tests ---"
+for t in "${dual_tests[@]}"; do
+  if [ -f "$t" ]; then
+    echo "  ok $t"
+  else
+    echo "  FAIL missing dual test $t"
+    fail=1
+  fi
+done
+
+# Optional: regen no-diff when SPECGEN_CHECK_REGEN=1 and specgen on PATH.
+# Catches Decision.tla drift against committed *spec packages.
+if [ "${SPECGEN_CHECK_REGEN:-}" = "1" ] && command -v specgen >/dev/null 2>&1; then
+  echo "--- regen no-diff (SPECGEN_CHECK_REGEN=1) ---"
+  if ! "$REPO_ROOT/scripts/regenerate-decision-cores.sh" >/tmp/regen-decision-cores.log 2>&1; then
+    echo "  FAIL regenerate-decision-cores.sh"
+    tail -20 /tmp/regen-decision-cores.log
+    fail=1
+  elif ! git -C "$REPO_ROOT" diff --quiet -- 'pkg/**/*spec/spec.go' 'pkg/**/*spec/spec_test.go' 2>/dev/null; then
+    echo "  FAIL generated packages drift after regenerate:"
+    git -C "$REPO_ROOT" diff --stat -- 'pkg/**/*spec/' || true
+    fail=1
+    # Restore tree so a failed check does not leave dirty sources.
+    git -C "$REPO_ROOT" checkout -- 'pkg/**/*spec/' 2>/dev/null || true
+  else
+    echo "  ok no drift"
+  fi
+fi
 
 if [ "$fail" -ne 0 ]; then
   echo "verify-decision-wires: FAILED"

--- a/specs/DECISION_CORES.md
+++ b/specs/DECISION_CORES.md
@@ -64,6 +64,19 @@ scripts/regenerate-decision-cores.sh timing-clamp
 
 Wire health: `scripts/verify-decision-wires.sh` (also from `check-specs.sh`).
 
+Checks:
+- Decision.tla present for each core
+- Generated `pkg/.../*spec/spec.go`
+- Production pure-gate symbols in non-test sources
+- Dual test files present
+- Optional: `SPECGEN_CHECK_REGEN=1` → regenerate + no-diff
+
+```bash
+scripts/verify-decision-wires.sh
+SPECGEN_CHECK_REGEN=1 scripts/verify-decision-wires.sh   # needs specgen on PATH
+scripts/regenerate-decision-cores.sh                     # after Decision.tla edits
+```
+
 Full TLC specs remain authoritative for multi-object interleavings.
 Decision cores pin the **pure decisions** that must not drift.
 


### PR DESCRIPTION
## Summary
Follow-up to #57 (merged). Tightens the decision-core stack health check:

- Dual test inventory for all 7 cores
- Optional `SPECGEN_CHECK_REGEN=1` regenerate + no-diff (when `specgen` on PATH)
- Docs in `specs/DECISION_CORES.md`

## Test plan
- [x] `scripts/verify-decision-wires.sh`
- [x] `SPECGEN_CHECK_REGEN=1 scripts/verify-decision-wires.sh`
- [x] `go test` dual filters
- [ ] CI green