### PR TITLE
Regenerate decision cores with pure predicates

### DIFF
--- a/pkg/analyzer/ghalifecyclespec/spec.go
+++ b/pkg/analyzer/ghalifecyclespec/spec.go
@@ -95,6 +95,23 @@ func (s State) EnabledActions() []string {
 	return out
 }
 
+// --- Pure operators (no primed vars; not actions) ---
+
+// PendingNeverFailed is the pure TLA+ operator PendingNeverFailed.
+func (s State) PendingNeverFailed() bool {
+	return !(s.CountedPending && s.CountedFailed)
+}
+
+// QueueOnlyNotPending is the pure TLA+ operator QueueOnlyNotPending.
+func (s State) QueueOnlyNotPending() bool {
+	return (!(s.QueueCounted) || (s.HasCompletedAt))
+}
+
+// BaitNeverPending is the pure TLA+ operator BaitNeverPending.
+func (s State) BaitNeverPending() bool {
+	return !(s.CountedPending)
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/analyzer/spantreespec/spec.go
+++ b/pkg/analyzer/spantreespec/spec.go
@@ -104,6 +104,18 @@ func (s State) EnabledActions() []string {
 	return out
 }
 
+// --- Pure operators (no primed vars; not actions) ---
+
+// Inv_RunnerWins is the pure TLA+ operator Inv_RunnerWins.
+func (s State) Inv_RunnerWins() bool {
+	return (!(s.Done && s.HaveAPI && s.HaveRunner) || (s.Kept == "runner"))
+}
+
+// BaitNeverRunner is the pure TLA+ operator BaitNeverRunner.
+func (s State) BaitNeverRunner() bool {
+	return s.Kept != "runner"
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/analyzer/timingclampspec/spec.go
+++ b/pkg/analyzer/timingclampspec/spec.go
@@ -103,6 +103,23 @@ func (s State) EnabledActions() []string {
 	return out
 }
 
+// --- Pure operators (no primed vars; not actions) ---
+
+// ClampedOrdered is the pure TLA+ operator ClampedOrdered.
+func (s State) ClampedOrdered() bool {
+	return (!(s.Phase == "clamped" || s.Phase == "done") || (s.OutStart < s.OutEnd))
+}
+
+// ClampedContained is the pure TLA+ operator ClampedContained.
+func (s State) ClampedContained() bool {
+	return (!(s.Phase == "clamped" || s.Phase == "done") || (s.OutStart >= s.ParentStart && (!(s.ParentEnd > s.ParentStart) || (s.OutStart <= s.ParentEnd-int64(1) && s.OutEnd <= s.ParentEnd))))
+}
+
+// BaitNeverDone is the pure TLA+ operator BaitNeverDone.
+func (s State) BaitNeverDone() bool {
+	return s.Phase != "done"
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/githubapi/rate_limit_decision_dual_test.go
+++ b/pkg/githubapi/rate_limit_decision_dual_test.go
@@ -70,9 +70,10 @@ func TestRateLimitWaitNeededMatchesDecision(t *testing.T) {
 	s = s.LearnExhausted()
 	// Exhausted, reset in future (resetAt = clock+1 in LearnExhausted).
 	until := time.Duration(s.ResetAt-s.Clock) * time.Second
+	assert.True(t, s.WaitNeeded(), "generated pure WaitNeeded after LearnExhausted")
 	assert.True(t, s.CanStartSleep())
 	assert.True(t, rateLimitWaitNeeded(int(s.Remaining), s.ResetAt > 0, until),
-		"production WaitNeeded must match CanStartSleep precondition")
+		"production rateLimitWaitNeeded must match generated WaitNeeded")
 
 	// Past reset: not needed.
 	assert.False(t, rateLimitWaitNeeded(0, true, 0))

--- a/pkg/githubapi/ratelimitspec/spec.go
+++ b/pkg/githubapi/ratelimitspec/spec.go
@@ -140,6 +140,23 @@ func (s State) EnabledActions() []string {
 	return out
 }
 
+// --- Pure operators (no primed vars; not actions) ---
+
+// WaitNeeded is the pure TLA+ operator WaitNeeded.
+func (s State) WaitNeeded() bool {
+	return s.Remaining == 0 && s.ResetAt > 0 && s.Clock < s.ResetAt
+}
+
+// NoSendWhileExhausted is the pure TLA+ operator NoSendWhileExhausted.
+func (s State) NoSendWhileExhausted() bool {
+	return !(s.SentWhileExhausted)
+}
+
+// BaitNeverSleep is the pure TLA+ operator BaitNeverSleep.
+func (s State) BaitNeverSleep() bool {
+	return !(s.Sleeping)
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/logparse/loggroupsspec/spec.go
+++ b/pkg/logparse/loggroupsspec/spec.go
@@ -84,6 +84,18 @@ func (s State) EnabledActions() []string {
 	return out
 }
 
+// --- Pure operators (no primed vars; not actions) ---
+
+// Inv_DepthNonNeg is the pure TLA+ operator Inv_DepthNonNeg.
+func (s State) Inv_DepthNonNeg() bool {
+	return s.Depth >= 0
+}
+
+// BaitNeverOpens is the pure TLA+ operator BaitNeverOpens.
+func (s State) BaitNeverOpens() bool {
+	return s.Depth == 0
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/store/sync_bounds_decision_dual_test.go
+++ b/pkg/store/sync_bounds_decision_dual_test.go
@@ -34,7 +34,8 @@ func TestSyncBoundsDecisionDual_OfferPaths(t *testing.T) {
 	assert.Equal(t, st.StoredAttempt, st.IncomingAttempt)
 	assert.True(t, acceptJobsAttempt(st.StoredAttempt, st.IncomingAttempt),
 		"OfferNewer must match UpsertJobs accept guard")
-	// NoStaleAccepted: accepted => incoming >= stored
+	// Generated pure invariant NoStaleAccepted (and compact form).
+	assert.True(t, st.NoStaleAccepted())
 	assert.GreaterOrEqual(t, st.IncomingAttempt, st.StoredAttempt)
 
 	// Store2 → OfferOlder: stale attempt must be rejected (Bug=FALSE).

--- a/pkg/store/syncboundsspec/spec.go
+++ b/pkg/store/syncboundsspec/spec.go
@@ -111,6 +111,18 @@ func (s State) EnabledActions() []string {
 	return out
 }
 
+// --- Pure operators (no primed vars; not actions) ---
+
+// NoStaleAccepted is the pure TLA+ operator NoStaleAccepted.
+func (s State) NoStaleAccepted() bool {
+	return (!(s.Accepted) || (s.IncomingAttempt >= s.StoredAttempt))
+}
+
+// BaitNeverAccepted is the pure TLA+ operator BaitNeverAccepted.
+func (s State) BaitNeverAccepted() bool {
+	return !(s.Accepted)
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/tui/results/tuireloadspec/spec.go
+++ b/pkg/tui/results/tuireloadspec/spec.go
@@ -139,6 +139,18 @@ func (s State) EnabledActions() []string {
 	return out
 }
 
+// --- Pure operators (no primed vars; not actions) ---
+
+// NoStaleAccepted is the pure TLA+ operator NoStaleAccepted.
+func (s State) NoStaleAccepted() bool {
+	return !(s.StaleAccepted)
+}
+
+// BaitNeverFetch is the pure TLA+ operator BaitNeverFetch.
+func (s State) BaitNeverFetch() bool {
+	return s.FetchJob == 0
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.


### PR DESCRIPTION
## Summary
Depends on/uses new `specgen` pure-predicate emission (dotai).

- Nullary unprimed operators → `func (s State) Name() bool`
- Regenerated all 7 `*spec` packages (`WaitNeeded`, `NoStaleAccepted`, …)
- Duals call generated predicates where available

Does **not** expand into records/multi-object — pure decision-module core stays.

## Test plan
- [x] `go test` all `*spec` packages
- [x] dual rate-limit / sync-bounds
- [x] `verify-decision-wires.sh`
- [x] `bazel build //:ote`
- [ ] CI green