### PR TITLE
Drop Bait pure preds; dual against generated invariants

### DIFF
--- a/pkg/analyzer/clamp_decision_dual_test.go
+++ b/pkg/analyzer/clamp_decision_dual_test.go
@@ -115,6 +115,8 @@ func TestClampDecisionDual(t *testing.T) {
 				"DoClamp outStart must match clampSpanToParent")
 			assert.Equal(t, gotE, st.OutEnd,
 				"DoClamp outEnd must match clampSpanToParent")
+			assert.True(t, st.ClampedOrdered(), "generated pure ClampedOrdered")
+			assert.True(t, st.ClampedContained(), "generated pure ClampedContained")
 
 			// Containment contract when parent is valid.
 			assert.Less(t, st.OutStart, st.OutEnd, "ordered")

--- a/pkg/analyzer/gha_lifecycle_decision_dual_test.go
+++ b/pkg/analyzer/gha_lifecycle_decision_dual_test.go
@@ -43,8 +43,9 @@ func TestGhaLifecycleDecisionDual_InitPendingFailure(t *testing.T) {
 	st = st.ClassifyPending()
 	assert.True(t, st.CountedPending)
 	assert.False(t, st.CountedFailed)
-	// PendingNeverFailed
+	// PendingNeverFailed (hand check + generated pure)
 	assert.False(t, st.CountedPending && st.CountedFailed)
+	assert.True(t, st.PendingNeverFailed())
 }
 
 // TestGhaLifecycleDecisionDual_CompletedFailure: after Reset, a completed

--- a/pkg/analyzer/ghalifecyclespec/spec.go
+++ b/pkg/analyzer/ghalifecyclespec/spec.go
@@ -107,11 +107,6 @@ func (s State) QueueOnlyNotPending() bool {
 	return (!(s.QueueCounted) || (s.HasCompletedAt))
 }
 
-// BaitNeverPending is the pure TLA+ operator BaitNeverPending.
-func (s State) BaitNeverPending() bool {
-	return !(s.CountedPending)
-}
-
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/analyzer/spantree_decision_dual_test.go
+++ b/pkg/analyzer/spantree_decision_dual_test.go
@@ -23,6 +23,7 @@ func TestDropAPIForRunnerTwinMatchesDecision(t *testing.T) {
 	require.True(t, s.CanDedupChoose())
 	s = s.DedupChoose()
 	assert.Equal(t, "runner", s.Kept)
+	assert.True(t, s.Inv_RunnerWins(), "generated pure Inv_RunnerWins after DedupChoose")
 	assert.True(t, dropAPIForRunnerTwin(1, 1, false),
 		"API side of twin must drop")
 	assert.False(t, dropAPIForRunnerTwin(1, 1, true),

--- a/pkg/analyzer/spantreespec/spec.go
+++ b/pkg/analyzer/spantreespec/spec.go
@@ -111,11 +111,6 @@ func (s State) Inv_RunnerWins() bool {
 	return (!(s.Done && s.HaveAPI && s.HaveRunner) || (s.Kept == "runner"))
 }
 
-// BaitNeverRunner is the pure TLA+ operator BaitNeverRunner.
-func (s State) BaitNeverRunner() bool {
-	return s.Kept != "runner"
-}
-
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/analyzer/timingclampspec/spec.go
+++ b/pkg/analyzer/timingclampspec/spec.go
@@ -115,11 +115,6 @@ func (s State) ClampedContained() bool {
 	return (!(s.Phase == "clamped" || s.Phase == "done") || (s.OutStart >= s.ParentStart && (!(s.ParentEnd > s.ParentStart) || (s.OutStart <= s.ParentEnd-int64(1) && s.OutEnd <= s.ParentEnd))))
 }
 
-// BaitNeverDone is the pure TLA+ operator BaitNeverDone.
-func (s State) BaitNeverDone() bool {
-	return s.Phase != "done"
-}
-
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/githubapi/ratelimitspec/spec.go
+++ b/pkg/githubapi/ratelimitspec/spec.go
@@ -152,11 +152,6 @@ func (s State) NoSendWhileExhausted() bool {
 	return !(s.SentWhileExhausted)
 }
 
-// BaitNeverSleep is the pure TLA+ operator BaitNeverSleep.
-func (s State) BaitNeverSleep() bool {
-	return !(s.Sleeping)
-}
-
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/logparse/loggroups_decision_dual_test.go
+++ b/pkg/logparse/loggroups_decision_dual_test.go
@@ -21,6 +21,7 @@ func TestGroupStackGatesMatchDecision(t *testing.T) {
 	assert.Equal(t, int64(0), s.Depth)
 	assert.True(t, s.CanOpen())
 	assert.False(t, s.CanClose())
+	assert.True(t, s.Inv_DepthNonNeg(), "generated pure Inv_DepthNonNeg at depth 0")
 	assert.True(t, canOpenGroup(0, 3))
 	assert.False(t, canCloseGroup(0), "CloseBug forbidden: no underflow")
 

--- a/pkg/logparse/loggroupsspec/spec.go
+++ b/pkg/logparse/loggroupsspec/spec.go
@@ -91,11 +91,6 @@ func (s State) Inv_DepthNonNeg() bool {
 	return s.Depth >= 0
 }
 
-// BaitNeverOpens is the pure TLA+ operator BaitNeverOpens.
-func (s State) BaitNeverOpens() bool {
-	return s.Depth == 0
-}
-
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/store/syncboundsspec/spec.go
+++ b/pkg/store/syncboundsspec/spec.go
@@ -118,11 +118,6 @@ func (s State) NoStaleAccepted() bool {
 	return (!(s.Accepted) || (s.IncomingAttempt >= s.StoredAttempt))
 }
 
-// BaitNeverAccepted is the pure TLA+ operator BaitNeverAccepted.
-func (s State) BaitNeverAccepted() bool {
-	return !(s.Accepted)
-}
-
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/tui/results/tuireload_decision_dual_test.go
+++ b/pkg/tui/results/tuireload_decision_dual_test.go
@@ -37,6 +37,10 @@ func TestLogFetchResultFreshMatchesDecision(t *testing.T) {
 	assert.True(t, s.CanFetchDiscard())
 	assert.False(t, logFetchResultFresh(s.FetchJob, s.FetchJob, int(s.FetchGen), int(s.ReloadGen)),
 		"production gate must match CanFetchDiscard after reload gen bump")
+	// Faithful path never accepts stale: FetchDiscard leaves StaleAccepted false.
+	require.True(t, s.CanFetchDiscard())
+	s = s.FetchDiscard()
+	assert.True(t, s.NoStaleAccepted(), "generated pure NoStaleAccepted after FetchDiscard")
 
 	// Wrong job never accepted.
 	assert.False(t, logFetchResultFresh(1, 2, 0, 0))

--- a/pkg/tui/results/tuireloadspec/spec.go
+++ b/pkg/tui/results/tuireloadspec/spec.go
@@ -146,11 +146,6 @@ func (s State) NoStaleAccepted() bool {
 	return !(s.StaleAccepted)
 }
 
-// BaitNeverFetch is the pure TLA+ operator BaitNeverFetch.
-func (s State) BaitNeverFetch() bool {
-	return s.FetchJob == 0
-}
-
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.


### PR DESCRIPTION
## Summary
Follow-up to #59 + specgen pure predicates:

- **specgen** (dotai): do not emit `Bait*` pure methods — TLC exploration only
- Regenerate all 7 `*spec` packages without Bait noise
- Dual tests call generated pure invs: `ClampedContained`, `Inv_RunnerWins`, `PendingNeverFailed`, `Inv_DepthNonNeg`, `NoStaleAccepted`

Core stays pure: still no records; baits stay TLC-only.

## Test plan
- [x] `go test` duals + *spec packages
- [x] `verify-decision-wires.sh`
- [x] `bazel build //:ote`
- [ ] CI green