### PR TITLE
PurePredicates registry on decision cores

### DIFF
--- a/pkg/analyzer/ghalifecyclespec/spec.go
+++ b/pkg/analyzer/ghalifecyclespec/spec.go
@@ -107,6 +107,20 @@ func (s State) QueueOnlyNotPending() bool {
 	return (!(s.QueueCounted) || (s.HasCompletedAt))
 }
 
+// PurePredicate is a named pure decision gate (no state change).
+type PurePredicate struct {
+	Name  string
+	Check func(State) bool
+}
+
+// PurePredicates returns every pure operator emitted for this module.
+func PurePredicates() []PurePredicate {
+	return []PurePredicate{
+		{Name: "PendingNeverFailed", Check: State.PendingNeverFailed},
+		{Name: "QueueOnlyNotPending", Check: State.QueueOnlyNotPending},
+	}
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/analyzer/ghalifecyclespec/spec_test.go
+++ b/pkg/analyzer/ghalifecyclespec/spec_test.go
@@ -53,3 +53,18 @@ func TestBFSReachability(t *testing.T) {
 	}
 	t.Logf("explored %d reachable states", len(seen))
 }
+
+// TestPurePredicates evaluates every pure operator on Init.
+// Ensures the registry is non-empty and methods do not panic.
+func TestPurePredicates(t *testing.T) {
+	s := Init()
+	preds := PurePredicates()
+	if len(preds) == 0 {
+		t.Fatal("PurePredicates empty")
+	}
+	for _, p := range preds {
+		t.Run(p.Name, func(t *testing.T) {
+			_ = p.Check(s) // must not panic
+		})
+	}
+}

--- a/pkg/analyzer/spantreespec/spec.go
+++ b/pkg/analyzer/spantreespec/spec.go
@@ -111,6 +111,19 @@ func (s State) Inv_RunnerWins() bool {
 	return (!(s.Done && s.HaveAPI && s.HaveRunner) || (s.Kept == "runner"))
 }
 
+// PurePredicate is a named pure decision gate (no state change).
+type PurePredicate struct {
+	Name  string
+	Check func(State) bool
+}
+
+// PurePredicates returns every pure operator emitted for this module.
+func PurePredicates() []PurePredicate {
+	return []PurePredicate{
+		{Name: "Inv_RunnerWins", Check: State.Inv_RunnerWins},
+	}
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/analyzer/spantreespec/spec_test.go
+++ b/pkg/analyzer/spantreespec/spec_test.go
@@ -50,3 +50,18 @@ func TestBFSReachability(t *testing.T) {
 	}
 	t.Logf("explored %d reachable states", len(seen))
 }
+
+// TestPurePredicates evaluates every pure operator on Init.
+// Ensures the registry is non-empty and methods do not panic.
+func TestPurePredicates(t *testing.T) {
+	s := Init()
+	preds := PurePredicates()
+	if len(preds) == 0 {
+		t.Fatal("PurePredicates empty")
+	}
+	for _, p := range preds {
+		t.Run(p.Name, func(t *testing.T) {
+			_ = p.Check(s) // must not panic
+		})
+	}
+}

--- a/pkg/analyzer/timingclampspec/spec.go
+++ b/pkg/analyzer/timingclampspec/spec.go
@@ -115,6 +115,20 @@ func (s State) ClampedContained() bool {
 	return (!(s.Phase == "clamped" || s.Phase == "done") || (s.OutStart >= s.ParentStart && (!(s.ParentEnd > s.ParentStart) || (s.OutStart <= s.ParentEnd-int64(1) && s.OutEnd <= s.ParentEnd))))
 }
 
+// PurePredicate is a named pure decision gate (no state change).
+type PurePredicate struct {
+	Name  string
+	Check func(State) bool
+}
+
+// PurePredicates returns every pure operator emitted for this module.
+func PurePredicates() []PurePredicate {
+	return []PurePredicate{
+		{Name: "ClampedOrdered", Check: State.ClampedOrdered},
+		{Name: "ClampedContained", Check: State.ClampedContained},
+	}
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/analyzer/timingclampspec/spec_test.go
+++ b/pkg/analyzer/timingclampspec/spec_test.go
@@ -59,3 +59,18 @@ func TestBFSReachability(t *testing.T) {
 	}
 	t.Logf("explored %d reachable states", len(seen))
 }
+
+// TestPurePredicates evaluates every pure operator on Init.
+// Ensures the registry is non-empty and methods do not panic.
+func TestPurePredicates(t *testing.T) {
+	s := Init()
+	preds := PurePredicates()
+	if len(preds) == 0 {
+		t.Fatal("PurePredicates empty")
+	}
+	for _, p := range preds {
+		t.Run(p.Name, func(t *testing.T) {
+			_ = p.Check(s) // must not panic
+		})
+	}
+}

--- a/pkg/githubapi/rate_limit_decision_dual_test.go
+++ b/pkg/githubapi/rate_limit_decision_dual_test.go
@@ -80,3 +80,20 @@ func TestRateLimitWaitNeededMatchesDecision(t *testing.T) {
 	assert.False(t, rateLimitWaitNeeded(0, true, -time.Second))
 	assert.False(t, rateLimitWaitNeeded(1, true, time.Hour))
 }
+
+// TestRateLimitPurePredicatesRegistry ensures the generated registry lists
+// WaitNeeded and is safe to enumerate (stack dual/CI pattern).
+func TestRateLimitPurePredicatesRegistry(t *testing.T) {
+	t.Parallel()
+	preds := ratelimitspec.PurePredicates()
+	require.NotEmpty(t, preds)
+	var sawWait bool
+	s := ratelimitspec.Init()
+	for _, p := range preds {
+		_ = p.Check(s)
+		if p.Name == "WaitNeeded" {
+			sawWait = true
+		}
+	}
+	assert.True(t, sawWait, "WaitNeeded must appear in PurePredicates")
+}

--- a/pkg/githubapi/ratelimitspec/spec.go
+++ b/pkg/githubapi/ratelimitspec/spec.go
@@ -152,6 +152,20 @@ func (s State) NoSendWhileExhausted() bool {
 	return !(s.SentWhileExhausted)
 }
 
+// PurePredicate is a named pure decision gate (no state change).
+type PurePredicate struct {
+	Name  string
+	Check func(State) bool
+}
+
+// PurePredicates returns every pure operator emitted for this module.
+func PurePredicates() []PurePredicate {
+	return []PurePredicate{
+		{Name: "WaitNeeded", Check: State.WaitNeeded},
+		{Name: "NoSendWhileExhausted", Check: State.NoSendWhileExhausted},
+	}
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/githubapi/ratelimitspec/spec_test.go
+++ b/pkg/githubapi/ratelimitspec/spec_test.go
@@ -53,3 +53,18 @@ func TestBFSReachability(t *testing.T) {
 	}
 	t.Logf("explored %d reachable states", len(seen))
 }
+
+// TestPurePredicates evaluates every pure operator on Init.
+// Ensures the registry is non-empty and methods do not panic.
+func TestPurePredicates(t *testing.T) {
+	s := Init()
+	preds := PurePredicates()
+	if len(preds) == 0 {
+		t.Fatal("PurePredicates empty")
+	}
+	for _, p := range preds {
+		t.Run(p.Name, func(t *testing.T) {
+			_ = p.Check(s) // must not panic
+		})
+	}
+}

--- a/pkg/logparse/loggroupsspec/spec.go
+++ b/pkg/logparse/loggroupsspec/spec.go
@@ -91,6 +91,19 @@ func (s State) Inv_DepthNonNeg() bool {
 	return s.Depth >= 0
 }
 
+// PurePredicate is a named pure decision gate (no state change).
+type PurePredicate struct {
+	Name  string
+	Check func(State) bool
+}
+
+// PurePredicates returns every pure operator emitted for this module.
+func PurePredicates() []PurePredicate {
+	return []PurePredicate{
+		{Name: "Inv_DepthNonNeg", Check: State.Inv_DepthNonNeg},
+	}
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/logparse/loggroupsspec/spec_test.go
+++ b/pkg/logparse/loggroupsspec/spec_test.go
@@ -41,3 +41,18 @@ func TestBFSReachability(t *testing.T) {
 	}
 	t.Logf("explored %d reachable states", len(seen))
 }
+
+// TestPurePredicates evaluates every pure operator on Init.
+// Ensures the registry is non-empty and methods do not panic.
+func TestPurePredicates(t *testing.T) {
+	s := Init()
+	preds := PurePredicates()
+	if len(preds) == 0 {
+		t.Fatal("PurePredicates empty")
+	}
+	for _, p := range preds {
+		t.Run(p.Name, func(t *testing.T) {
+			_ = p.Check(s) // must not panic
+		})
+	}
+}

--- a/pkg/store/syncboundsspec/spec.go
+++ b/pkg/store/syncboundsspec/spec.go
@@ -118,6 +118,19 @@ func (s State) NoStaleAccepted() bool {
 	return (!(s.Accepted) || (s.IncomingAttempt >= s.StoredAttempt))
 }
 
+// PurePredicate is a named pure decision gate (no state change).
+type PurePredicate struct {
+	Name  string
+	Check func(State) bool
+}
+
+// PurePredicates returns every pure operator emitted for this module.
+func PurePredicates() []PurePredicate {
+	return []PurePredicate{
+		{Name: "NoStaleAccepted", Check: State.NoStaleAccepted},
+	}
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/store/syncboundsspec/spec_test.go
+++ b/pkg/store/syncboundsspec/spec_test.go
@@ -50,3 +50,18 @@ func TestBFSReachability(t *testing.T) {
 	}
 	t.Logf("explored %d reachable states", len(seen))
 }
+
+// TestPurePredicates evaluates every pure operator on Init.
+// Ensures the registry is non-empty and methods do not panic.
+func TestPurePredicates(t *testing.T) {
+	s := Init()
+	preds := PurePredicates()
+	if len(preds) == 0 {
+		t.Fatal("PurePredicates empty")
+	}
+	for _, p := range preds {
+		t.Run(p.Name, func(t *testing.T) {
+			_ = p.Check(s) // must not panic
+		})
+	}
+}

--- a/pkg/tui/results/tuireloadspec/spec.go
+++ b/pkg/tui/results/tuireloadspec/spec.go
@@ -146,6 +146,19 @@ func (s State) NoStaleAccepted() bool {
 	return !(s.StaleAccepted)
 }
 
+// PurePredicate is a named pure decision gate (no state change).
+type PurePredicate struct {
+	Name  string
+	Check func(State) bool
+}
+
+// PurePredicates returns every pure operator emitted for this module.
+func PurePredicates() []PurePredicate {
+	return []PurePredicate{
+		{Name: "NoStaleAccepted", Check: State.NoStaleAccepted},
+	}
+}
+
 // --- Trace emission for conformance checking ---
 
 // TraceEntry is a single recorded transition for conformance validation.

--- a/pkg/tui/results/tuireloadspec/spec_test.go
+++ b/pkg/tui/results/tuireloadspec/spec_test.go
@@ -53,3 +53,18 @@ func TestBFSReachability(t *testing.T) {
 	}
 	t.Logf("explored %d reachable states", len(seen))
 }
+
+// TestPurePredicates evaluates every pure operator on Init.
+// Ensures the registry is non-empty and methods do not panic.
+func TestPurePredicates(t *testing.T) {
+	s := Init()
+	preds := PurePredicates()
+	if len(preds) == 0 {
+		t.Fatal("PurePredicates empty")
+	}
+	for _, p := range preds {
+		t.Run(p.Name, func(t *testing.T) {
+			_ = p.Check(s) // must not panic
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Uses new `specgen` **PurePredicates** registry:

- `type PurePredicate { Name; Check func(State) bool }`
- `PurePredicates()` lists every pure gate
- Generated `TestPurePredicates` smokes each on Init
- Rate-limit dual asserts `WaitNeeded` is registered

All 7 decision cores regenerated. Core still pure (no records; no Bait*).

## Test plan
- [x] `go test` *spec packages
- [x] dual registry test
- [x] `verify-decision-wires.sh`
- [x] `bazel build //:ote`
- [ ] CI green