### PR TITLE
Dual PurePredicates registry across all decision cores

### DIFF
--- a/pkg/analyzer/clamp_decision_dual_test.go
+++ b/pkg/analyzer/clamp_decision_dual_test.go
@@ -185,3 +185,22 @@ func TestClampDecisionDual_BugPassthrough(t *testing.T) {
 	// Mutation violates containment: outEnd 4 > parentEnd 3
 	assert.Greater(t, st.OutEnd, int64(3))
 }
+
+func TestClampPurePredicatesRegistry(t *testing.T) {
+	t.Parallel()
+	preds := timingclampspec.PurePredicates()
+	require.NotEmpty(t, preds)
+	s := timingclampspec.Init()
+	var sawContained, sawOrdered bool
+	for _, p := range preds {
+		_ = p.Check(s)
+		switch p.Name {
+		case "ClampedContained":
+			sawContained = true
+		case "ClampedOrdered":
+			sawOrdered = true
+		}
+	}
+	assert.True(t, sawContained)
+	assert.True(t, sawOrdered)
+}

--- a/pkg/analyzer/gha_lifecycle_decision_dual_test.go
+++ b/pkg/analyzer/gha_lifecycle_decision_dual_test.go
@@ -192,3 +192,18 @@ func TestGhaLifecycleDecisionDual_Table(t *testing.T) {
 		})
 	}
 }
+
+func TestGhaLifecyclePurePredicatesRegistry(t *testing.T) {
+	t.Parallel()
+	preds := ghalifecyclespec.PurePredicates()
+	require.NotEmpty(t, preds)
+	s := ghalifecyclespec.Init()
+	var saw bool
+	for _, p := range preds {
+		_ = p.Check(s)
+		if p.Name == "PendingNeverFailed" {
+			saw = true
+		}
+	}
+	assert.True(t, saw)
+}

--- a/pkg/analyzer/spantree_decision_dual_test.go
+++ b/pkg/analyzer/spantree_decision_dual_test.go
@@ -35,3 +35,18 @@ func TestDropAPIForRunnerTwinMatchesDecision(t *testing.T) {
 	assert.False(t, dropAPIForRunnerTwin(2, 1, false))
 	assert.False(t, dropAPIForRunnerTwin(1, 2, false))
 }
+
+func TestSpanTreePurePredicatesRegistry(t *testing.T) {
+	t.Parallel()
+	preds := spantreespec.PurePredicates()
+	require.NotEmpty(t, preds)
+	s := spantreespec.Init()
+	var saw bool
+	for _, p := range preds {
+		_ = p.Check(s)
+		if p.Name == "Inv_RunnerWins" {
+			saw = true
+		}
+	}
+	assert.True(t, saw)
+}

--- a/pkg/logparse/loggroups_decision_dual_test.go
+++ b/pkg/logparse/loggroups_decision_dual_test.go
@@ -59,3 +59,18 @@ func TestSplitGroupsStrayEndgroupNoUnderflow(t *testing.T) {
 	require.Len(t, groups, 1)
 	assert.Equal(t, "Tail", groups[0].name)
 }
+
+func TestLogGroupsPurePredicatesRegistry(t *testing.T) {
+	t.Parallel()
+	preds := loggroupsspec.PurePredicates()
+	require.NotEmpty(t, preds)
+	s := loggroupsspec.Init()
+	var saw bool
+	for _, p := range preds {
+		_ = p.Check(s)
+		if p.Name == "Inv_DepthNonNeg" {
+			saw = true
+		}
+	}
+	assert.True(t, saw)
+}

--- a/pkg/store/sync_bounds_decision_dual_test.go
+++ b/pkg/store/sync_bounds_decision_dual_test.go
@@ -116,3 +116,18 @@ func TestSyncBoundsDecisionDual_AgainstStore(t *testing.T) {
 		assert.False(t, dec.Accepted)
 	}
 }
+
+func TestSyncBoundsPurePredicatesRegistry(t *testing.T) {
+	t.Parallel()
+	preds := syncboundsspec.PurePredicates()
+	require.NotEmpty(t, preds)
+	s := syncboundsspec.Init()
+	var saw bool
+	for _, p := range preds {
+		_ = p.Check(s)
+		if p.Name == "NoStaleAccepted" {
+			saw = true
+		}
+	}
+	assert.True(t, saw)
+}

--- a/pkg/tui/results/tuireload_decision_dual_test.go
+++ b/pkg/tui/results/tuireload_decision_dual_test.go
@@ -46,3 +46,18 @@ func TestLogFetchResultFreshMatchesDecision(t *testing.T) {
 	assert.False(t, logFetchResultFresh(1, 2, 0, 0))
 	assert.False(t, logFetchResultFresh(0, 1, 0, 0))
 }
+
+func TestTuiReloadPurePredicatesRegistry(t *testing.T) {
+	t.Parallel()
+	preds := tuireloadspec.PurePredicates()
+	require.NotEmpty(t, preds)
+	s := tuireloadspec.Init()
+	var saw bool
+	for _, p := range preds {
+		_ = p.Check(s)
+		if p.Name == "NoStaleAccepted" {
+			saw = true
+		}
+	}
+	assert.True(t, saw)
+}

--- a/scripts/verify-decision-wires.sh
+++ b/scripts/verify-decision-wires.sh
@@ -76,6 +76,11 @@ echo "--- generated packages ---"
 for p in "${gen_pkgs[@]}"; do
   if [ -f "$p" ]; then
     echo "  ok $p"
+    # PurePredicates registry is required for dual/CI enumeration.
+    if ! grep -F -q 'func PurePredicates()' "$p" 2>/dev/null; then
+      echo "  FAIL $p missing PurePredicates() registry"
+      fail=1
+    fi
   else
     echo "  FAIL missing $p"
     fail=1

--- a/specs/DECISION_CORES.md
+++ b/specs/DECISION_CORES.md
@@ -66,10 +66,18 @@ Wire health: `scripts/verify-decision-wires.sh` (also from `check-specs.sh`).
 
 Checks:
 - Decision.tla present for each core
-- Generated `pkg/.../*spec/spec.go`
+- Generated `pkg/.../*spec/spec.go` with `PurePredicates()` registry
 - Production pure-gate symbols in non-test sources
-- Dual test files present
+- Dual test files present (semantic duals + registry smoke)
 - Optional: `SPECGEN_CHECK_REGEN=1` → regenerate + no-diff
+
+Generated pure API (per `*spec` package):
+
+```go
+func (s State) WaitNeeded() bool          // example pure gate
+func PurePredicates() []PurePredicate     // enumerate all pure gates
+// TestPurePredicates — generated smoke on Init
+```
 
 ```bash
 scripts/verify-decision-wires.sh


### PR DESCRIPTION
## Summary
Follow-up to #61 (merged). Adoption of the pure-predicate registry:

- Registry dual smokes for all 7 cores (key gate name asserted)
- `verify-decision-wires` requires `PurePredicates()` in each `*spec`
- Docs in `DECISION_CORES.md`

## Test plan
- [x] `go test` PurePredicatesRegistry across packages
- [x] `verify-decision-wires.sh`
- [x] `bazel build //:ote`
- [ ] CI green