### PR TITLE
Dual tests in check-specs + decision-stack-status

### DIFF
--- a/scripts/check-specs.sh
+++ b/scripts/check-specs.sh
@@ -252,6 +252,33 @@ else
   fail=$((fail + 1))
 fi
 
+# Dual tests pin production gates to generated Can*/pure preds. Run a
+# filtered suite when go is available so the tla-specs job (not only the
+# unit-test job) exercises the stack bridge.
+echo
+echo "--- dual tests (production ↔ decision) ---"
+if command -v go >/dev/null 2>&1; then
+  # Broad but safe filter: dual files use these name patterns.
+  dual_run='Decision|PurePredicates|Dual|GroupStack|LogFetchResultFresh|DropAPI|ClampDecision|RateLimit|SyncBounds'
+  declare -a DUAL_PKGS=(
+    "pkg/analyzer"
+    "pkg/githubapi"
+    "pkg/store"
+    "pkg/logparse"
+    "pkg/tui/results"
+  )
+  for dpkg in "${DUAL_PKGS[@]}"; do
+    if (cd "$REPO_ROOT" && go test "./$dpkg/" -run "$dual_run" -count=1 >/dev/null 2>&1); then
+      printf '%-22s %-40s %s\n' "dual" "./$dpkg/" 'ok'
+    else
+      printf '%-22s %-40s %s\n' "dual" "./$dpkg/" 'FAIL ✗'
+      fail=$((fail + 1))
+    fi
+  done
+else
+  echo "go not on PATH — skip dual package tests"
+fi
+
 echo
 echo "specs: $pass ok, $fail failed"
 [ $fail -eq 0 ]

--- a/scripts/decision-stack-status.sh
+++ b/scripts/decision-stack-status.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# decision-stack-status.sh — human-readable inventory of the decision-core stack.
+#
+# Prints one row per subsystem: TLC full, decision core, generated package,
+# pure preds, production gates. No TLC/JVM required.
+#
+# Usage: scripts/decision-stack-status.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# core|gen_pkg|prod_symbols (comma-separated)
+rows=(
+  "tui-reload|pkg/tui/results/tuireloadspec|logFetchResultFresh"
+  "rate-limit|pkg/githubapi/ratelimitspec|rateLimitWaitNeeded"
+  "timing-clamp|pkg/analyzer/timingclampspec|DoClamp(via timingclampspec)"
+  "sync-bounds|pkg/store/syncboundsspec|acceptJobsAttempt"
+  "gha-lifecycle|pkg/analyzer/ghalifecyclespec|countsFailed,countsQueue"
+  "log-groups|pkg/logparse/loggroupsspec|canOpenGroup,canCloseGroup"
+  "span-tree|pkg/analyzer/spantreespec|dropAPIForRunnerTwin"
+)
+
+printf '%-14s %-6s %-8s %-10s %-28s %s\n' \
+  "CORE" "FULL" "DECISION" "GEN" "PURE_PREDS" "PRODUCTION"
+printf '%-14s %-6s %-8s %-10s %-28s %s\n' \
+  "----" "----" "--------" "---" "----------" "----------"
+
+for row in "${rows[@]}"; do
+  core="${row%%|*}"
+  rest="${row#*|}"
+  gen="${rest%%|*}"
+  prod="${rest#*|}"
+
+  full="no"
+  if find "specs/$core" -maxdepth 1 -name '*.tla' 2>/dev/null | grep -q .; then
+    full="yes"
+  fi
+
+  decision="no"
+  [ -f "specs/$core/decision/Decision.tla" ] && decision="yes"
+
+  genok="no"
+  [ -f "$gen/spec.go" ] && genok="yes"
+
+  preds="-"
+  if [ -f "$gen/spec.go" ]; then
+    preds=$(grep -oE 'Name: "[A-Za-z0-9_]+"' "$gen/spec.go" 2>/dev/null \
+      | sed 's/Name: "//;s/"$//' \
+      | tr '\n' ',' \
+      | sed 's/,$//')
+    [ -n "$preds" ] || preds="(none)"
+  fi
+
+  printf '%-14s %-6s %-8s %-10s %-28s %s\n' \
+    "$core" "$full" "$decision" "$genok" "${preds:0:28}" "$prod"
+done
+
+echo
+echo "Legend: FULL=specs/<core>/*.tla  DECISION=decision/Decision.tla  GEN=committed *spec"
+echo "Verify: scripts/verify-decision-wires.sh · scripts/check-specs.sh"

--- a/specs/DECISION_CORES.md
+++ b/specs/DECISION_CORES.md
@@ -80,10 +80,11 @@ func PurePredicates() []PurePredicate     // enumerate all pure gates
 ```
 
 ```bash
+scripts/decision-stack-status.sh                         # inventory table
 scripts/verify-decision-wires.sh
 SPECGEN_CHECK_REGEN=1 scripts/verify-decision-wires.sh   # needs specgen on PATH
 scripts/regenerate-decision-cores.sh                     # after Decision.tla edits
-scripts/check-specs.sh                                   # TLC + go test all *spec (go, not specgen)
+scripts/check-specs.sh                                   # TLC + *spec + duals + wires
 ```
 
 CI (`tla-specs` job) always runs committed `go test ./pkg/.../*spec` when `go`


### PR DESCRIPTION
## Summary
After #63 (merged):

1. **`check-specs.sh`** runs dual package tests when `go` is available
   (production ↔ generated decision gates)
2. **`scripts/decision-stack-status.sh`** — one-screen inventory of the stack

## Test plan
- [x] `decision-stack-status.sh`
- [x] dual filter tests all packages
- [x] `check-specs.sh log-groups`
- [ ] CI green