### PR TITLE
Add GATES.md agent SSOT for all decision cores

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,13 @@ Two layers:
    hermetic `//tools/specgen` into `pkg/.../*spec/`. Never hand-edit
    generated `spec.go` / `spec_test.go`.
 
+**Agent default:** load `specs/GATES.md` → `specs/<core>/GATES.md` only.  
+Open full `.tla` only for race redesign. Cite **symbols**, not line numbers.
+
 ```bash
 bazel test //tools/decision:up_to_date   # codegen freshness (in bazel test //...)
 bazel run  //tools/decision:update       # regenerate committed *spec from .tla
+scripts/decision-stack-status.sh
 ```
 
 Rules for changes:

--- a/specs/DECISION_CORES.md
+++ b/specs/DECISION_CORES.md
@@ -1,5 +1,8 @@
 # Decision cores (specgen bridge)
 
+**Agent entrypoint for code changes:** [GATES.md](GATES.md)  
+(per-core: `specs/<name>/GATES.md` — not the full TLC model).
+
 The full TLC specs under `specs/*/` use records, multi-object interleavings,
 and other shapes that stay outside the **pure decision-module** core of
 `specgen`. They remain the **design model-checkers**.

--- a/specs/GATES.md
+++ b/specs/GATES.md
@@ -1,0 +1,17 @@
+# Gates index (agent entrypoint)
+
+**Day-to-day:** load `specs/<core>/GATES.md` only.  
+**Race redesign:** full TLC in `specs/<core>/*.tla`.  
+**Regen:** `bazel run //tools/decision:update`
+
+| Core | GATES | Production package |
+|------|-------|--------------------|
+| tui-reload | [tui-reload/GATES.md](tui-reload/GATES.md) | `pkg/tui/results` |
+| rate-limit | [rate-limit/GATES.md](rate-limit/GATES.md) | `pkg/githubapi` |
+| timing-clamp | [timing-clamp/GATES.md](timing-clamp/GATES.md) | `pkg/analyzer` |
+| sync-bounds | [sync-bounds/GATES.md](sync-bounds/GATES.md) | `pkg/store` |
+| gha-lifecycle | [gha-lifecycle/GATES.md](gha-lifecycle/GATES.md) | `pkg/analyzer` |
+| log-groups | [log-groups/GATES.md](log-groups/GATES.md) | `pkg/logparse` |
+| span-tree | [span-tree/GATES.md](span-tree/GATES.md) | `pkg/analyzer` |
+
+Inventory: `scripts/decision-stack-status.sh`

--- a/specs/gha-lifecycle/GATES.md
+++ b/specs/gha-lifecycle/GATES.md
@@ -1,0 +1,14 @@
+# gha-lifecycle — gates (agent SSOT)
+
+Load this for code changes. Full TLC for multi-attempt runs: `GhaLifecycle.tla`.
+
+| Gate | Production | Decision | Generated pure |
+|------|------------|----------|----------------|
+| Job still pending | `isJobPending` | ClassifyPending | — |
+| Count as failed | `countsFailed` | ClassifyFailed | `PendingNeverFailed` |
+| Count queue time | `countsQueue` | ClassifyQueue | `QueueOnlyNotPending` |
+| Package | `pkg/analyzer` | `decision/Decision.tla` | `ghalifecyclespec` |
+
+**Rule:** pending never failed; queue only non-pending (and not skipped/cancelled).
+
+**Check:** `bazel test //pkg/analyzer:analyzer_test --test_filter=GhaLifecycle|Pure`

--- a/specs/log-groups/GATES.md
+++ b/specs/log-groups/GATES.md
@@ -1,0 +1,13 @@
+# log-groups — gates (agent SSOT)
+
+Load this for code changes. Full TLC for timestamps/gaps: `LogGroups.tla`.
+
+| Gate | Production | Decision | Generated pure |
+|------|------------|----------|----------------|
+| May open group | `canOpenGroup` | Open | — |
+| May close group | `canCloseGroup` | Close | `Inv_DepthNonNeg` |
+| Package | `pkg/logparse` | `decision/Decision.tla` | `loggroupsspec` |
+
+**Rule:** never underflow depth (stray endgroup is no-op).
+
+**Check:** `bazel test //pkg/logparse:logparse_test --test_filter=GroupStack|LogGroups|Pure`

--- a/specs/rate-limit/GATES.md
+++ b/specs/rate-limit/GATES.md
@@ -1,0 +1,13 @@
+# rate-limit — gates (agent SSOT)
+
+Load this for code changes. Full TLC only for multi-goroutine races: `RateLimit.tla`.
+
+| Gate | Production | Decision | Generated pure |
+|------|------------|----------|----------------|
+| Must wait before send | `rateLimitWaitNeeded` | StartSleep / WaitNeeded | `WaitNeeded` |
+| Recheck after sleep | `waitIfNeeded` loop | WakeRecheckSend / Resleep | — |
+| Package | `pkg/githubapi` | `decision/Decision.tla` | `ratelimitspec` |
+
+**Rule:** after sleep, recheck; do not fire blind while still exhausted.
+
+**Check:** `bazel test //pkg/githubapi:githubapi_test --test_filter=RateLimit|Pure`

--- a/specs/span-tree/GATES.md
+++ b/specs/span-tree/GATES.md
@@ -1,0 +1,12 @@
+# span-tree — gates (agent SSOT)
+
+Load this for code changes. Full TLC for pipeline/cycles: `SpanTree.tla`.
+
+| Gate | Production | Decision | Generated pure |
+|------|------------|----------|----------------|
+| Drop API twin | `dropAPIForRunnerTwin` | DedupChoose | `Inv_RunnerWins` |
+| Package | `pkg/analyzer` | `decision/Decision.tla` | `spantreespec` |
+
+**Rule:** when group is exactly {1 API, 1 runner}, drop the API span.
+
+**Check:** `bazel test //pkg/analyzer:analyzer_test --test_filter=DropAPI|Dedup|SpanTree|Pure`

--- a/specs/sync-bounds/GATES.md
+++ b/specs/sync-bounds/GATES.md
@@ -1,0 +1,12 @@
+# sync-bounds — gates (agent SSOT)
+
+Load this for code changes. Full TLC for multi-run sync: `SyncBounds.tla`.
+
+| Gate | Production | Decision | Generated pure |
+|------|------------|----------|----------------|
+| Accept jobs write | `acceptJobsAttempt` (+ SQL) | OfferNewer / OfferOlder | `NoStaleAccepted` |
+| Package | `pkg/store` | `decision/Decision.tla` | `syncboundsspec` |
+
+**Rule:** accept if `incoming==0` (unknown) or `incoming==stored`. SQL is atomic twin.
+
+**Check:** `bazel test //pkg/store:store_test --test_filter=SyncBounds|Pure`

--- a/specs/timing-clamp/GATES.md
+++ b/specs/timing-clamp/GATES.md
@@ -1,0 +1,12 @@
+# timing-clamp — gates (agent SSOT)
+
+Load this for code changes. Full TLC for pipeline faults: `TimingClamp.tla`.
+
+| Gate | Production | Decision | Generated pure |
+|------|------------|----------|----------------|
+| Clamp child to parent | `clampSpanToParent` → **DoClamp** | DoClamp | `ClampedOrdered`, `ClampedContained` |
+| Package | `pkg/analyzer` | `decision/Decision.tla` | `timingclampspec` |
+
+**SSOT:** production calls generated `DoClamp` (not a hand formula).
+
+**Check:** `bazel test //pkg/analyzer:analyzer_test --test_filter=Clamp|Pure`

--- a/specs/tui-reload/GATES.md
+++ b/specs/tui-reload/GATES.md
@@ -1,0 +1,12 @@
+# tui-reload — gates (agent SSOT)
+
+Load this for code changes. Full TLC only for race redesign: `TuiReload.tla`.
+
+| Gate | Production | Decision | Generated pure |
+|------|------------|----------|----------------|
+| Fresh log-fetch result | `logFetchResultFresh` | FetchAccept / FetchDiscard | `NoStaleAccepted` |
+| Package | `pkg/tui/results` | `decision/Decision.tla` | `tuireloadspec` |
+
+**Rule:** accept only if `msgJob == fetchingJob` and `msgGen == reloadGen`.
+
+**Check:** `bazel test //pkg/tui/results:results_test --test_filter=LogFetch|TuiReload|Pure`


### PR DESCRIPTION
## Summary
Lean token win for TLA+ day-to-day work:

- `specs/GATES.md` — index
- `specs/<core>/GATES.md` — 5–10 line gate tables (7 cores)
- AGENTS + DECISION_CORES: load GATES first, full TLC only for race redesign
- Symbol cites (no line numbers)

## Test plan
- [x] Files present for all 7 cores
- [x] `bazel test //tools/decision:up_to_date`
- [x] `bazel build //:ote`
- [ ] CI green