### PR TITLE
Lean decision-check: tags + script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ Two layers:
 Open full `.tla` only for race redesign. Cite **symbols**, not line numbers.
 
 ```bash
+scripts/decision-check.sh                # lean: wires + decision-tagged tests
+scripts/decision-check.sh --with-tlc     # also TLC cores (or pass core names)
 bazel test //tools/decision:up_to_date   # codegen freshness (in bazel test //...)
 bazel run  //tools/decision:update       # regenerate committed *spec from .tla
 scripts/decision-stack-status.sh

--- a/pkg/analyzer/ghalifecyclespec/BUILD.bazel
+++ b/pkg/analyzer/ghalifecyclespec/BUILD.bazel
@@ -17,4 +17,5 @@ go_test(
     name = "ghalifecyclespec_test",
     srcs = ["//tools/decision:gha_lifecycle_gen/spec_test.go"],
     embed = [":ghalifecyclespec"],
+    tags = ["decision"],
 )

--- a/pkg/analyzer/spantreespec/BUILD.bazel
+++ b/pkg/analyzer/spantreespec/BUILD.bazel
@@ -17,4 +17,5 @@ go_test(
     name = "spantreespec_test",
     srcs = ["//tools/decision:span_tree_gen/spec_test.go"],
     embed = [":spantreespec"],
+    tags = ["decision"],
 )

--- a/pkg/analyzer/timingclampspec/BUILD.bazel
+++ b/pkg/analyzer/timingclampspec/BUILD.bazel
@@ -25,4 +25,5 @@ go_test(
     name = "timingclampspec_test",
     srcs = ["//tools/decision:timing_clamp_gen/spec_test.go"],
     embed = [":timingclampspec"],
+    tags = ["decision"],
 )

--- a/pkg/githubapi/ratelimitspec/BUILD.bazel
+++ b/pkg/githubapi/ratelimitspec/BUILD.bazel
@@ -21,4 +21,5 @@ go_test(
         "//tools/decision:rate_limit_gen/spec_test.go",
     ],
     embed = [":ratelimitspec"],
+    tags = ["decision"],
 )

--- a/pkg/logparse/loggroupsspec/BUILD.bazel
+++ b/pkg/logparse/loggroupsspec/BUILD.bazel
@@ -17,4 +17,5 @@ go_test(
     name = "loggroupsspec_test",
     srcs = ["//tools/decision:log_groups_gen/spec_test.go"],
     embed = [":loggroupsspec"],
+    tags = ["decision"],
 )

--- a/pkg/store/syncboundsspec/BUILD.bazel
+++ b/pkg/store/syncboundsspec/BUILD.bazel
@@ -17,4 +17,5 @@ go_test(
     name = "syncboundsspec_test",
     srcs = ["//tools/decision:sync_bounds_gen/spec_test.go"],
     embed = [":syncboundsspec"],
+    tags = ["decision"],
 )

--- a/pkg/tui/results/tuireloadspec/BUILD.bazel
+++ b/pkg/tui/results/tuireloadspec/BUILD.bazel
@@ -21,4 +21,5 @@ go_test(
         "//tools/decision:tui_reload_gen/spec_test.go",
     ],
     embed = [":tuireloadspec"],
+    tags = ["decision"],
 )

--- a/scripts/decision-check.sh
+++ b/scripts/decision-check.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# decision-check.sh — lean decision-core gate (no full-repo TLC by default).
+#
+# Fast path after gate/symbol edits:
+#   1. Production wire symbols still exist
+#   2. Bazel tests tagged decision (*spec duals + codegen up_to_date)
+#   3. Optional: TLC for named cores (full + decision for that core)
+#
+# Full design TLC for everything: scripts/check-specs.sh
+#
+# Usage:
+#   scripts/decision-check.sh              # wires + bazel decision tags
+#   scripts/decision-check.sh --with-tlc   # also TLC every core with decision/
+#   scripts/decision-check.sh <core> ...   # TLC only those cores (implies TLC)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WITH_TLC=0
+CORES=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --with-tlc) WITH_TLC=1 ;;
+    -h|--help)
+      sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      CORES+=("$arg")
+      WITH_TLC=1
+      ;;
+  esac
+done
+
+fail=0
+
+echo "=== decision wires ==="
+if ! "$REPO_ROOT/scripts/verify-decision-wires.sh"; then
+  fail=1
+fi
+
+echo
+echo "=== bazel --test_tag_filters=decision ==="
+if ! bazel test //... --test_tag_filters=decision --test_output=errors; then
+  fail=1
+fi
+
+if [ "$WITH_TLC" -eq 1 ]; then
+  echo
+  echo "=== TLC (decision cores) ==="
+  if [ ${#CORES[@]} -eq 0 ]; then
+    while IFS= read -r core; do
+      CORES+=("$core")
+    done < <(
+      find specs -path '*/decision/Decision.tla' -print \
+        | sed 's|^specs/||;s|/decision/Decision.tla$||' \
+        | sort
+    )
+  fi
+  if [ ${#CORES[@]} -eq 0 ]; then
+    echo "no decision cores found under specs/*/decision/"
+    fail=1
+  else
+    # check-specs skips cleanly when no JVM/tlc; still runs package duals.
+    if ! "$REPO_ROOT/scripts/check-specs.sh" "${CORES[@]}"; then
+      fail=1
+    fi
+  fi
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "decision-check: FAIL"
+  exit 1
+fi
+echo "decision-check: OK"
+exit 0

--- a/scripts/decision-stack-status.sh
+++ b/scripts/decision-stack-status.sh
@@ -59,4 +59,4 @@ done
 
 echo
 echo "Legend: FULL=specs/<core>/*.tla  DECISION=decision/Decision.tla  GEN=committed *spec"
-echo "Verify: scripts/verify-decision-wires.sh · scripts/check-specs.sh"
+echo "Verify: scripts/decision-check.sh · scripts/check-specs.sh"

--- a/specs/GATES.md
+++ b/specs/GATES.md
@@ -2,7 +2,9 @@
 
 **Day-to-day:** load `specs/<core>/GATES.md` only.  
 **Race redesign:** full TLC in `specs/<core>/*.tla`.  
-**Regen:** `bazel run //tools/decision:update`
+**Regen:** `bazel run //tools/decision:update`  
+**Lean check:** `scripts/decision-check.sh`  
+(`--with-tlc` or `<core>` for TLC; full suite: `scripts/check-specs.sh`)
 
 | Core | GATES | Production package |
 |------|-------|--------------------|

--- a/tools/decision/BUILD.bazel
+++ b/tools/decision/BUILD.bazel
@@ -83,6 +83,7 @@ decision_core(
 
 test_suite(
     name = "up_to_date",
+    tags = ["decision"],
     tests = [
         ":tui_reload_up_to_date",
         ":rate_limit_up_to_date",

--- a/tools/decision/defs.bzl
+++ b/tools/decision/defs.bzl
@@ -75,4 +75,5 @@ rm -rf "$$tmpdir"
             src_test,
         ],
         size = "small",
+        tags = ["decision"],
     )


### PR DESCRIPTION
## Summary
- Tag all 7 `*spec` go_tests and decision `up_to_date` sh_tests with `decision`
- Add `scripts/decision-check.sh`: wires + `bazel test --test_tag_filters=decision` (+ optional TLC)
- Point `specs/GATES.md` and `AGENTS.md` at the lean gate

## Verify
- `scripts/decision-check.sh` → OK (14/14 decision tests)
- `bazel build //:ote` → OK

## Follow-up (not this PR)
- Symbol cites in dual tests / more prod→gen pure gates