### PR TITLE
Symbol cites only for decision-facing docs

### DIFF
--- a/pkg/githubapi/rate_limit_decision_dual_test.go
+++ b/pkg/githubapi/rate_limit_decision_dual_test.go
@@ -4,7 +4,7 @@ package githubapi
 //
 // Spec: specs/rate-limit/decision/Decision.tla (FINDING 13 wake recheck)
 // Generated: pkg/githubapi/ratelimitspec (never hand-edit)
-// Production: waitIfNeeded loop client.go:361-379
+// Production: rateLimitWaitNeeded / waitIfNeeded recheck loop
 
 import (
 	"context"

--- a/specs/GATES.md
+++ b/specs/GATES.md
@@ -4,7 +4,9 @@
 **Race redesign:** full TLC in `specs/<core>/*.tla`.  
 **Regen:** `bazel run //tools/decision:update`  
 **Lean check:** `scripts/decision-check.sh`  
-(`--with-tlc` or `<core>` for TLC; full suite: `scripts/check-specs.sh`)
+(`--with-tlc` or `<core>` for TLC; full suite: `scripts/check-specs.sh`)  
+**Cites:** production / decision / pure **symbols** only — never `file.go:line`
+(lines rot; GATES + duals are the map).
 
 | Core | GATES | Production package |
 |------|-------|--------------------|

--- a/specs/gha-lifecycle/decision/Decision.tla
+++ b/specs/gha-lifecycle/decision/Decision.tla
@@ -9,10 +9,10 @@
 (* This core pins the pure isPending / FailedJobs / countsQueueTime        *)
 (* guards so they cannot drift from the generated Go module.               *)
 (*                                                                         *)
-(* analyzer.go:                                                            *)
-(*   isJobPending     : status != completed OR CompletedAt empty  (:816)   *)
-(*   FailedJobs       : not pending AND (failure OR timed_out)    (:904)   *)
-(*   countsQueueTime  : not pending AND not skipped/cancelled     (:924)   *)
+(* Production symbols (pkg/analyzer):                                      *)
+(*   isJobPending     : status != completed OR CompletedAt empty           *)
+(*   countsFailed     : not pending AND (failure OR timed_out)             *)
+(*   countsQueue      : not pending AND not skipped/cancelled              *)
 (*                                                                         *)
 (* Abstraction: status is folded into hasCompletedAt for the interesting   *)
 (* fault (completed with empty completed_at is still pending). Pending     *)
@@ -46,7 +46,7 @@ Init ==
   /\ countedFailed = FALSE
   /\ queueCounted = FALSE
 
-\* ClassifyPending - analyzer.go:855-864.
+\* ClassifyPending — production isJobPending.
 \* Only pending jobs land in PendingJobs.
 \* Pending = ~hasCompletedAt (isJobPending with status=completed assumed).
 ClassifyPending ==
@@ -55,7 +55,7 @@ ClassifyPending ==
   /\ countedPending' = TRUE
   /\ UNCHANGED <<hasCompletedAt, conclusion, countedFailed, queueCounted>>
 
-\* ClassifyFailed - analyzer.go:903-906.
+\* ClassifyFailed — production countsFailed.
 \* Faithful: not pending AND (failure OR timed_out).
 \* Bug=TRUE drops the not-pending guard (MCMutation of full GhaLifecycle).
 ClassifyFailed ==
@@ -65,7 +65,7 @@ ClassifyFailed ==
   /\ countedFailed' = TRUE
   /\ UNCHANGED <<hasCompletedAt, conclusion, countedPending, queueCounted>>
 
-\* ClassifyQueue - analyzer.go:924-926 countsQueueTime.
+\* ClassifyQueue — production countsQueue (countsQueueTime).
 \* Faithful: not pending (and not skipped/cancelled - those conclusions are
 \* outside this core's domain, so the conclusion gate is always open here).
 \* Bug=TRUE drops the not-pending guard (same tooth as BugQueueUngated).

--- a/specs/gha-lifecycle/decision/README.md
+++ b/specs/gha-lifecycle/decision/README.md
@@ -19,9 +19,9 @@ Pin the pure classification guards:
 
 | Action | Code |
 |--------|------|
-| `ClassifyPending` | `isJobPending` → `PendingJobs` (analyzer.go:855-864) |
-| `ClassifyFailed` | `!isPending && (failure \|\| timed_out)` (analyzer.go:903-906) |
-| `ClassifyQueue` | `countsQueueTime` gate (analyzer.go:924-926) |
+| `ClassifyPending` | `isJobPending` → `PendingJobs` |
+| `ClassifyFailed` | `countsFailed` (`!isPending && failure\|timed_out`) |
+| `ClassifyQueue` | `countsQueue` / `countsQueueTime` |
 | `Reset` | clear counts; advance scenario to completed failure/timeout/success |
 
 `IsPending` here is `~hasCompletedAt` — models the completed-but-no-timestamp

--- a/specs/log-groups/decision/Decision.tla
+++ b/specs/log-groups/decision/Decision.tla
@@ -60,8 +60,8 @@ Spec == Init /\ [][Next]_vars
 
 -----------------------------------------------------------------------------
 \* [code-documented] Group stack never underflows when Bug is off.
-\* Maps to splitGroups ignoring stray ##[endgroup] when current is nil
-\* (timestamp.go:65-72). CloseBug only enabled under Bug.
+\* Maps to canCloseGroup / splitGroups ignoring stray ##[endgroup].
+\* CloseBug only enabled under Bug.
 Inv_DepthNonNeg == depth >= 0
 
 \* BAIT: claims depth never leaves 0. Open reaches depth 1 — MUST FAIL.

--- a/specs/log-groups/decision/README.md
+++ b/specs/log-groups/decision/README.md
@@ -17,13 +17,13 @@ This core is **specgen-clean**: int + bool only.
 
 | Action | Guard | Effect | Code |
 |--------|-------|--------|------|
-| `Open` | `depth >= 0 /\ depth < MaxDepth` | `depth+1` | `timestamp.go:51-63` open group |
-| `Close` | `depth > 0` | `depth-1` | `timestamp.go:65-72` endgroup when open |
+| `Open` | `depth >= 0 /\ depth < MaxDepth` | `depth+1` | `canOpenGroup` |
+| `Close` | `depth > 0` | `depth-1` | `canCloseGroup` |
 | `CloseBug` | `Bug /\ depth = 0` | `depth-1` (underflow) | mutation: endgroup at empty stack |
 | `Terminating` | — | stutter | terminal/idle |
 
-Production ignores stray endgroup when no current group
-(`timestamp.go:66-71`). That is `~CloseBug` / `Inv_DepthNonNeg`.
+Production ignores stray endgroup when no open group
+(`canCloseGroup` false). That is `~CloseBug` / `Inv_DepthNonNeg`.
 
 ## Invariants
 

--- a/specs/rate-limit/decision/Decision.tla
+++ b/specs/rate-limit/decision/Decision.tla
@@ -43,7 +43,7 @@ VARIABLES
 
 vars == <<remaining, sleeping, clock, resetAt, sentWhileExhausted>>
 
-\* Client-side waitDuration() > 0 (client.go:349-359): remaining exhausted,
+\* Client-side waitDuration > 0 / rateLimitWaitNeeded: remaining exhausted,
 \* reset known (non-zero), reset still in the future.
 WaitNeeded == remaining = 0 /\ resetAt > 0 /\ clock < resetAt
 
@@ -66,8 +66,8 @@ Init ==
 (* ACTIONS *)
 
 (* A delivered response reports the primary limit exhausted with a future
-   reset (updateFromHeaders, client.go:401-418). Models learning remaining=0
-   from headers while still holding some local remaining count. *)
+   reset (updateFromHeaders). Models learning remaining=0 from headers
+   while still holding some local remaining count. *)
 LearnExhausted ==
   /\ remaining > 0
   /\ clock < MaxClock
@@ -75,8 +75,7 @@ LearnExhausted ==
   /\ resetAt' = clock + 1
   /\ UNCHANGED <<sleeping, clock, sentWhileExhausted>>
 
-(* waitIfNeeded sees WaitNeeded, sleeps outside the lock
-   (client.go:361-379). *)
+(* waitIfNeeded sees WaitNeeded / rateLimitWaitNeeded, sleeps outside lock. *)
 StartSleep ==
   /\ remaining = 0
   /\ ~sleeping
@@ -86,7 +85,7 @@ StartSleep ==
   /\ UNCHANGED <<remaining, clock, resetAt, sentWhileExhausted>>
 
 (* Faithful recheck: sleep timer / loop iteration finds WaitNeeded still
-   true → stay sleeping (client.go:361-379 for-loop continues).
+   true → stay sleeping (waitIfNeeded for-loop continues).
    Disabled under Bug so the mutation path is forced through WakeBugSend. *)
 WakeRecheckResleep ==
   /\ ~Bug

--- a/specs/rate-limit/decision/README.md
+++ b/specs/rate-limit/decision/README.md
@@ -17,7 +17,7 @@ Maps to:
 | Action | Code |
 |--------|------|
 | `LearnExhausted` | `updateFromHeaders` → remaining=0, future reset |
-| `StartSleep` | `waitIfNeeded` + `sleepContext` (client.go:361-379) |
+| `StartSleep` | `rateLimitWaitNeeded` / `waitIfNeeded` + `sleepContext` |
 | `WakeRecheckSend` | loop recheck: `waitDuration()==0` → return |
 | `WakeRecheckResleep` | loop recheck: still waiting → sleep again |
 | `WakeBugSend` | pre-fix fire-without-recheck (`Bug=TRUE`) |
@@ -35,7 +35,7 @@ Maps to:
 | `sentWhileExhausted` | monitor: bug-path wake while `WaitNeeded` |
 
 `WaitNeeded == remaining=0 /\ resetAt>0 /\ clock<resetAt`
-mirrors `waitDuration() > 0` (client.go:349-359).
+mirrors `waitDuration > 0` / production `rateLimitWaitNeeded`.
 
 ## Correct sequence (recheck)
 

--- a/specs/span-tree/decision/Decision.tla
+++ b/specs/span-tree/decision/Decision.tla
@@ -87,7 +87,7 @@ Spec == Init /\ [][Next]_vars
 
 -----------------------------------------------------------------------------
 \* [code-documented] Unambiguous {1 api, 1 runner} group → runner wins.
-\* dedup.go:46-48; TestRunnerSpanDedup.
+\* Production dropAPIForRunnerTwin / TestRunnerSpanDedup.
 Inv_RunnerWins ==
     (done /\ haveAPI /\ haveRunner) => kept = "runner"
 

--- a/specs/span-tree/decision/README.md
+++ b/specs/span-tree/decision/README.md
@@ -22,7 +22,7 @@ This core is **specgen-clean**: bool + string only.
 |--------|-------|--------|------|
 | `SeeAPI` | `~done /\ ~haveAPI` | `haveAPI=TRUE` | observe API span in group |
 | `SeeRunner` | `~done /\ ~haveRunner` | `haveRunner=TRUE` | observe runner span in group |
-| `DedupChoose` | `~done /\ (haveAPI \/ haveRunner)` | both → `kept="runner"` | `dedup.go:46-48` runner wins |
+| `DedupChoose` | `~done /\ (haveAPI \/ haveRunner)` | both → `kept="runner"` | `dropAPIForRunnerTwin` |
 | `DedupBug` | `Bug /\ both` | `kept="api"` | mutation: wrong keep |
 | `Terminating` | `done` | stutter | post-dedup |
 

--- a/specs/sync-bounds/decision/Decision.tla
+++ b/specs/sync-bounds/decision/Decision.tla
@@ -8,7 +8,7 @@
 (* Full design model: specs/sync-bounds/SyncBounds.tla (multi-run sync).  *)
 (* This core pins the pure "stale attempt cannot stomp newer" decision:    *)
 (*                                                                         *)
-(*   store.go:390-400 UpsertJobs                                           *)
+(* Production: acceptJobsAttempt + UpsertJobs                              *)
 (*     UPDATE runs SET jobs_fetched=1                                      *)
 (*     WHERE attempt is 0 OR run_attempt matches incoming                  *)
 (*   accept only when incoming is 0 (unknown) or equals stored.            *)
@@ -38,7 +38,7 @@ Init ==
   /\ accepted = FALSE
 
 \* Store1/2/3 set (or bump) the stored run_attempt.
-\* Mirrors UpsertRuns writing run_attempt (store.go:167). Separate named
+\* Mirrors UpsertRuns writing run_attempt. Separate named
 \* actions (no quantifier) so specgen stays on the simple dispatcher path.
 Store1 ==
   /\ (phase = "empty" \/ phase = "stored")
@@ -70,7 +70,7 @@ OfferNewer ==
   /\ UNCHANGED storedAttempt
 
 \* Offer a jobs write for an OLDER attempt (stale in-flight worker).
-\* Faithful (Bug=FALSE): rejected - store.go:390-400 rows-affected = 0.
+\* Faithful (Bug=FALSE): rejected — acceptJobsAttempt false / rows=0.
 \* Mutation (Bug=TRUE): accepted - pre-fix unconditional jobs_fetched=1.
 OfferOlder ==
   /\ phase = "stored"

--- a/specs/sync-bounds/decision/README.md
+++ b/specs/sync-bounds/decision/README.md
@@ -1,7 +1,7 @@
 # SyncBoundsDecision — UpsertJobs attempt-guard decision core
 
 Scalar state machine for **one** stale-vs-current attempt decision in
-`UpsertJobs` (`pkg/store/store.go:390-400`). Specgen-compatible subset.
+`UpsertJobs` / `acceptJobsAttempt`. Specgen-compatible subset.
 
 Full multi-run design model: `../SyncBounds.tla`.
 
@@ -19,7 +19,7 @@ Pin the pure guard so production code cannot drift:
 
 | Action | Code |
 |--------|------|
-| `Store1` / `Store2` / `Store3` | `UpsertRuns` writes `run_attempt` (store.go:167) |
+| `Store1` / `Store2` / `Store3` | `UpsertRuns` writes `run_attempt` |
 | `OfferNewer` | `UpsertJobs` with `attempt == run_attempt` → accept |
 | `OfferOlder` | `UpsertJobs` with stale attempt → discard (Bug=TRUE: stomp) |
 

--- a/specs/timing-clamp/decision/Decision.tla
+++ b/specs/timing-clamp/decision/Decision.tla
@@ -9,7 +9,7 @@
 (* This core pins the pure clamp decision so it cannot drift from the      *)
 (* generated Go module (pkg/analyzer/timingclampspec).                     *)
 (*                                                                         *)
-(* Mirrors clampSpanToParent in pkg/analyzer/analyzer.go:826:              *)
+(* Mirrors production clampSpanToParent → generated DoClamp:               *)
 (*   pe  = parentEnd if parentEnd > parentStart else parentStart + 1       *)
 (*   cs  = clamp start into [parentStart, pe-1]                            *)
 (*   ce0 = min(end, pe)                                                    *)
@@ -56,7 +56,7 @@ SetHostile ==
   /\ parentEnd' = 3
   /\ UNCHANGED <<phase, outStart, outEnd>>
 
-\* Faithful clamp - mirrors analyzer.go:826 / ClampSpan in TimingClamp.tla.
+\* Faithful clamp — clampSpanToParent / DoClamp / ClampSpan (full TLC).
 \* Only enabled when Bug = FALSE.
 
 DoClamp ==

--- a/specs/timing-clamp/decision/README.md
+++ b/specs/timing-clamp/decision/README.md
@@ -1,7 +1,7 @@
 # TimingClampDecision — clampSpanToParent decision core
 
-Scalar state machine for **one** application of `clampSpanToParent`
-(`pkg/analyzer/analyzer.go:826`). Specgen-compatible subset only.
+Scalar state machine for **one** application of `clampSpanToParent` /
+`DoClamp`. Specgen-compatible subset only.
 
 - File: `Decision.tla` (SANY module name = filename)
 - Logical name: TimingClampDecision

--- a/specs/tui-reload/decision/Decision.tla
+++ b/specs/tui-reload/decision/Decision.tla
@@ -19,13 +19,13 @@ This core pins the pure decisions production code must obey:
   6. FetchStaleBug: Bug path that wrongly accepts a stale result
      (staleAccepted' = TRUE) — mutation target for NoStaleAccepted.
 
-Maps to pkg/tui/results:
-  PressReload   → model.go key r + doReload (isLoading guard)
+Maps to pkg/tui/results symbols:
+  PressReload   → doReload (isLoading key guard)
   ReloadDone    → ReloadResultMsg success (reloadGen++, clear expected job)
-  PressFetchN   → fetchLogsForCurrentItem (stamps gen at logfetch.go:61)
-  FetchAccept   → LogFetchResultMsg when msg.gen == m.reloadGen
-  FetchDiscard  → LogFetchResultMsg discard (model.go:365-372)
-  FetchStaleBug → pre-fix code that attributed any result (Bug2 era)
+  PressFetchN   → fetchLogsForCurrentItem (stamps gen)
+  FetchAccept   → logFetchResultFresh true → apply
+  FetchDiscard  → logFetchResultFresh false → discard
+  FetchStaleBug → pre-fix accept-any (Bug2 era)
 
 Scalar-only: no records, no quantifiers in actions, no sequences.
 ***************************************************************************)
@@ -48,8 +48,8 @@ Init ==
   /\ fetchGen = 0
   /\ staleAccepted = FALSE
 
-\* User presses r. Faithful: keys dropped while isLoading (model.go:473-479).
-\* Bug=TRUE removes that guard. Gen bumps on ReloadDone (model.go:410).
+\* User presses r. Faithful: keys dropped while isLoading.
+\* Bug=TRUE removes that guard. Gen bumps on ReloadDone.
 PressReload ==
   /\ (Bug \/ ~isLoading)
   /\ reloadGen < MaxGen

--- a/specs/tui-reload/decision/README.md
+++ b/specs/tui-reload/decision/README.md
@@ -16,11 +16,11 @@ Maps to:
 
 | Action | Code |
 |--------|------|
-| `PressReload` | `model.go` key `r` + `doReload`; isLoading guard |
-| `ReloadDone` | `ReloadResultMsg` success: `reloadGen++` (`model.go:410`) |
-| `PressFetch1/2` | `fetchLogsForCurrentItem` stamps `gen` (`logfetch.go:61`) |
-| `FetchAccept` | `LogFetchResultMsg` when `msg.gen == m.reloadGen` |
-| `FetchDiscard` | discard path `model.go:365-372` |
+| `PressReload` | `doReload`; isLoading key guard |
+| `ReloadDone` | `ReloadResultMsg` success: `reloadGen++` |
+| `PressFetch1/2` | `fetchLogsForCurrentItem` stamps `gen` |
+| `FetchAccept` | `logFetchResultFresh` true → apply |
+| `FetchDiscard` | `logFetchResultFresh` false → discard |
 | `FetchStaleBug` | mutation: pre-fix "accept any result" (Bug=TRUE) |
 
 ## State (scalars)
@@ -79,9 +79,9 @@ conform \
 
 See `pkg/tui/results/tuireloadspec/conform_test.go`.
 
-## Dual-test note (model.go)
+## Dual-test note
 
-Real discard rule (`model.go:365-372`):
+Real discard rule (`logFetchResultFresh`):
 
 ```go
 if msg.jobID == 0 || msg.jobID != m.logFetchingJobID || msg.gen != m.reloadGen {


### PR DESCRIPTION
## Summary
Item 3 from the TLA stack plan: **symbol cites**, not `file.go:line`.

- Strip line numbers from all 7 `specs/*/decision/` READMEs + Decision.tla comments
- Map tables to production symbols (`countsFailed`, `logFetchResultFresh`, …)
- Dual header for rate-limit uses symbols
- `specs/GATES.md` rule: symbols only

Left alone (historical / rare agent path):
- full TLC READMEs, FINDINGS.md line maps

## Verify
- `scripts/decision-check.sh` → OK
- `bazel test //tools/decision:up_to_date` → OK
- `bazel build //:ote` → OK