### PR TITLE
Prod SSOT: WaitNeeded + CanClose via generated pure

### DIFF
--- a/pkg/githubapi/BUILD.bazel
+++ b/pkg/githubapi/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/stefanpenner/otel-explorer/pkg/githubapi",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/githubapi/ratelimitspec",
         "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:otelhttp",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//attribute",

--- a/pkg/githubapi/client.go
+++ b/pkg/githubapi/client.go
@@ -17,6 +17,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/stefanpenner/otel-explorer/pkg/githubapi/ratelimitspec"
+
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -348,11 +350,25 @@ type rateLimiter struct {
 	resetTime time.Time
 }
 
-// rateLimitWaitNeeded is the RateLimitDecision WaitNeeded predicate:
+// rateLimitWaitNeeded is the RateLimitDecision WaitNeeded pure gate:
 // remaining exhausted, reset known, and the reset is still in the future.
-// Spec: specs/rate-limit/decision WaitNeeded (client.go waitDuration > 0).
+// Spec: specs/rate-limit/decision WaitNeeded → ratelimitspec.WaitNeeded.
+// SSOT: production calls the generated pure (scalar encoding of duration).
 func rateLimitWaitNeeded(remaining int, resetKnown bool, untilReset time.Duration) bool {
-	return remaining == 0 && resetKnown && untilReset > 0
+	resetAt := int64(0)
+	if resetKnown {
+		resetAt = 1
+	}
+	clock := int64(0)
+	if untilReset <= 0 {
+		// At or past reset: clock >= resetAt so WaitNeeded is false.
+		clock = resetAt
+	}
+	return ratelimitspec.State{
+		Remaining: int64(remaining),
+		ResetAt:   resetAt,
+		Clock:     clock,
+	}.WaitNeeded()
 }
 
 // waitDuration computes how long the caller must wait before issuing a

--- a/pkg/logparse/BUILD.bazel
+++ b/pkg/logparse/BUILD.bazel
@@ -12,6 +12,9 @@ go_library(
     ],
     importpath = "github.com/stefanpenner/otel-explorer/pkg/logparse",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/logparse/loggroupsspec",
+    ],
 )
 
 go_test(

--- a/pkg/logparse/timestamp.go
+++ b/pkg/logparse/timestamp.go
@@ -7,6 +7,8 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/stefanpenner/otel-explorer/pkg/logparse/loggroupsspec"
 )
 
 // TimestampParser is a generic fallback parser that creates spans based on
@@ -41,6 +43,8 @@ type groupBlock struct {
 // canOpenGroup / canCloseGroup are the LogGroupsDecision stack gates.
 // Spec: specs/log-groups/decision Open / Close (Bug=FALSE forbids Close at 0).
 // maxDepth <= 0 means unbounded (production); the decision core uses MaxDepth=3.
+// canCloseGroup is SSOT via generated CanClose; canOpenGroup stays parametric
+// because production allows unbounded maxDepth (generated CanOpen hardcodes 3).
 func canOpenGroup(depth, maxDepth int) bool {
 	if depth < 0 {
 		return false
@@ -52,7 +56,7 @@ func canOpenGroup(depth, maxDepth int) bool {
 }
 
 func canCloseGroup(depth int) bool {
-	return depth > 0
+	return loggroupsspec.State{Depth: int64(depth)}.CanClose()
 }
 
 // splitGroups partitions log lines into top-level lines and group blocks.

--- a/specs/log-groups/GATES.md
+++ b/specs/log-groups/GATES.md
@@ -4,10 +4,12 @@ Load this for code changes. Full TLC for timestamps/gaps: `LogGroups.tla`.
 
 | Gate | Production | Decision | Generated pure |
 |------|------------|----------|----------------|
-| May open group | `canOpenGroup` | Open | — |
-| May close group | `canCloseGroup` | Close | `Inv_DepthNonNeg` |
+| May open group | `canOpenGroup` (parametric) | Open | — |
+| May close group | `canCloseGroup` → **CanClose** | Close | `CanClose`, `Inv_DepthNonNeg` |
 | Package | `pkg/logparse` | `decision/Decision.tla` | `loggroupsspec` |
 
+**SSOT:** production `canCloseGroup` calls generated `CanClose`.  
+Open stays parametric (prod unbounded depth; core MaxDepth=3).  
 **Rule:** never underflow depth (stray endgroup is no-op).
 
 **Check:** `bazel test //pkg/logparse:logparse_test --test_filter=GroupStack|LogGroups|Pure`

--- a/specs/rate-limit/GATES.md
+++ b/specs/rate-limit/GATES.md
@@ -4,10 +4,11 @@ Load this for code changes. Full TLC only for multi-goroutine races: `RateLimit.
 
 | Gate | Production | Decision | Generated pure |
 |------|------------|----------|----------------|
-| Must wait before send | `rateLimitWaitNeeded` | StartSleep / WaitNeeded | `WaitNeeded` |
+| Must wait before send | `rateLimitWaitNeeded` → **WaitNeeded** | StartSleep / WaitNeeded | `WaitNeeded` |
 | Recheck after sleep | `waitIfNeeded` loop | WakeRecheckSend / Resleep | — |
 | Package | `pkg/githubapi` | `decision/Decision.tla` | `ratelimitspec` |
 
+**SSOT:** production `rateLimitWaitNeeded` calls generated `WaitNeeded`.  
 **Rule:** after sleep, recheck; do not fire blind while still exhausted.
 
 **Check:** `bazel test //pkg/githubapi:githubapi_test --test_filter=RateLimit|Pure`


### PR DESCRIPTION
## Summary
Item 4 (cheap slice): more production gates call generated pure/action.

| Production | Generated |
|------------|-----------|
| `rateLimitWaitNeeded` | `ratelimitspec.WaitNeeded` |
| `canCloseGroup` | `loggroupsspec.CanClose` |

Same pattern as `clampSpanToParent` → `DoClamp`.

**Left parametric / dual-only (not free):**
- `canOpenGroup` — prod unbounded maxDepth; core hardcodes MaxDepth=3
- `acceptJobsAttempt`, `logFetchResultFresh`, gha/span gates — no 1:1 pure with same shape without awkward state encoding

## Verify
- `bazel test //pkg/githubapi:githubapi_test //pkg/logparse:logparse_test //tools/decision:up_to_date`
- `scripts/decision-check.sh`
- `bazel build //:ote`