### PR TITLE
PurePredicates dual stub from codegen (item 5)

### DIFF
--- a/pkg/analyzer/clamp_decision_dual_test.go
+++ b/pkg/analyzer/clamp_decision_dual_test.go
@@ -186,21 +186,3 @@ func TestClampDecisionDual_BugPassthrough(t *testing.T) {
 	assert.Greater(t, st.OutEnd, int64(3))
 }
 
-func TestClampPurePredicatesRegistry(t *testing.T) {
-	t.Parallel()
-	preds := timingclampspec.PurePredicates()
-	require.NotEmpty(t, preds)
-	s := timingclampspec.Init()
-	var sawContained, sawOrdered bool
-	for _, p := range preds {
-		_ = p.Check(s)
-		switch p.Name {
-		case "ClampedContained":
-			sawContained = true
-		case "ClampedOrdered":
-			sawOrdered = true
-		}
-	}
-	assert.True(t, sawContained)
-	assert.True(t, sawOrdered)
-}

--- a/pkg/analyzer/gha_lifecycle_decision_dual_test.go
+++ b/pkg/analyzer/gha_lifecycle_decision_dual_test.go
@@ -193,17 +193,3 @@ func TestGhaLifecycleDecisionDual_Table(t *testing.T) {
 	}
 }
 
-func TestGhaLifecyclePurePredicatesRegistry(t *testing.T) {
-	t.Parallel()
-	preds := ghalifecyclespec.PurePredicates()
-	require.NotEmpty(t, preds)
-	s := ghalifecyclespec.Init()
-	var saw bool
-	for _, p := range preds {
-		_ = p.Check(s)
-		if p.Name == "PendingNeverFailed" {
-			saw = true
-		}
-	}
-	assert.True(t, saw)
-}

--- a/pkg/analyzer/ghalifecyclespec/spec_test.go
+++ b/pkg/analyzer/ghalifecyclespec/spec_test.go
@@ -54,17 +54,34 @@ func TestBFSReachability(t *testing.T) {
 	t.Logf("explored %d reachable states", len(seen))
 }
 
-// TestPurePredicates evaluates every pure operator on Init.
-// Ensures the registry is non-empty and methods do not panic.
+// TestPurePredicates is the generated pure-gate dual stub.
+// Names come from Decision.tla (SSOT); dual package tests cover production wiring.
 func TestPurePredicates(t *testing.T) {
+	want := []string{
+		"PendingNeverFailed",
+		"QueueOnlyNotPending",
+	}
 	s := Init()
 	preds := PurePredicates()
-	if len(preds) == 0 {
-		t.Fatal("PurePredicates empty")
+	if len(preds) != len(want) {
+		t.Fatalf("PurePredicates len=%d want %d", len(preds), len(want))
 	}
+	got := make(map[string]bool, len(preds))
 	for _, p := range preds {
+		if p.Name == "" {
+			t.Fatal("empty PurePredicate.Name")
+		}
+		if got[p.Name] {
+			t.Fatalf("duplicate pure name %q", p.Name)
+		}
+		got[p.Name] = true
 		t.Run(p.Name, func(t *testing.T) {
 			_ = p.Check(s) // must not panic
 		})
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Fatalf("missing pure %q in PurePredicates()", name)
+		}
 	}
 }

--- a/pkg/analyzer/spantree_decision_dual_test.go
+++ b/pkg/analyzer/spantree_decision_dual_test.go
@@ -36,17 +36,3 @@ func TestDropAPIForRunnerTwinMatchesDecision(t *testing.T) {
 	assert.False(t, dropAPIForRunnerTwin(1, 2, false))
 }
 
-func TestSpanTreePurePredicatesRegistry(t *testing.T) {
-	t.Parallel()
-	preds := spantreespec.PurePredicates()
-	require.NotEmpty(t, preds)
-	s := spantreespec.Init()
-	var saw bool
-	for _, p := range preds {
-		_ = p.Check(s)
-		if p.Name == "Inv_RunnerWins" {
-			saw = true
-		}
-	}
-	assert.True(t, saw)
-}

--- a/pkg/analyzer/spantreespec/spec_test.go
+++ b/pkg/analyzer/spantreespec/spec_test.go
@@ -51,17 +51,33 @@ func TestBFSReachability(t *testing.T) {
 	t.Logf("explored %d reachable states", len(seen))
 }
 
-// TestPurePredicates evaluates every pure operator on Init.
-// Ensures the registry is non-empty and methods do not panic.
+// TestPurePredicates is the generated pure-gate dual stub.
+// Names come from Decision.tla (SSOT); dual package tests cover production wiring.
 func TestPurePredicates(t *testing.T) {
+	want := []string{
+		"Inv_RunnerWins",
+	}
 	s := Init()
 	preds := PurePredicates()
-	if len(preds) == 0 {
-		t.Fatal("PurePredicates empty")
+	if len(preds) != len(want) {
+		t.Fatalf("PurePredicates len=%d want %d", len(preds), len(want))
 	}
+	got := make(map[string]bool, len(preds))
 	for _, p := range preds {
+		if p.Name == "" {
+			t.Fatal("empty PurePredicate.Name")
+		}
+		if got[p.Name] {
+			t.Fatalf("duplicate pure name %q", p.Name)
+		}
+		got[p.Name] = true
 		t.Run(p.Name, func(t *testing.T) {
 			_ = p.Check(s) // must not panic
 		})
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Fatalf("missing pure %q in PurePredicates()", name)
+		}
 	}
 }

--- a/pkg/analyzer/timingclampspec/spec_test.go
+++ b/pkg/analyzer/timingclampspec/spec_test.go
@@ -60,17 +60,34 @@ func TestBFSReachability(t *testing.T) {
 	t.Logf("explored %d reachable states", len(seen))
 }
 
-// TestPurePredicates evaluates every pure operator on Init.
-// Ensures the registry is non-empty and methods do not panic.
+// TestPurePredicates is the generated pure-gate dual stub.
+// Names come from Decision.tla (SSOT); dual package tests cover production wiring.
 func TestPurePredicates(t *testing.T) {
+	want := []string{
+		"ClampedOrdered",
+		"ClampedContained",
+	}
 	s := Init()
 	preds := PurePredicates()
-	if len(preds) == 0 {
-		t.Fatal("PurePredicates empty")
+	if len(preds) != len(want) {
+		t.Fatalf("PurePredicates len=%d want %d", len(preds), len(want))
 	}
+	got := make(map[string]bool, len(preds))
 	for _, p := range preds {
+		if p.Name == "" {
+			t.Fatal("empty PurePredicate.Name")
+		}
+		if got[p.Name] {
+			t.Fatalf("duplicate pure name %q", p.Name)
+		}
+		got[p.Name] = true
 		t.Run(p.Name, func(t *testing.T) {
 			_ = p.Check(s) // must not panic
 		})
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Fatalf("missing pure %q in PurePredicates()", name)
+		}
 	}
 }

--- a/pkg/githubapi/rate_limit_decision_dual_test.go
+++ b/pkg/githubapi/rate_limit_decision_dual_test.go
@@ -81,19 +81,3 @@ func TestRateLimitWaitNeededMatchesDecision(t *testing.T) {
 	assert.False(t, rateLimitWaitNeeded(1, true, time.Hour))
 }
 
-// TestRateLimitPurePredicatesRegistry ensures the generated registry lists
-// WaitNeeded and is safe to enumerate (stack dual/CI pattern).
-func TestRateLimitPurePredicatesRegistry(t *testing.T) {
-	t.Parallel()
-	preds := ratelimitspec.PurePredicates()
-	require.NotEmpty(t, preds)
-	var sawWait bool
-	s := ratelimitspec.Init()
-	for _, p := range preds {
-		_ = p.Check(s)
-		if p.Name == "WaitNeeded" {
-			sawWait = true
-		}
-	}
-	assert.True(t, sawWait, "WaitNeeded must appear in PurePredicates")
-}

--- a/pkg/githubapi/ratelimitspec/spec_test.go
+++ b/pkg/githubapi/ratelimitspec/spec_test.go
@@ -54,17 +54,34 @@ func TestBFSReachability(t *testing.T) {
 	t.Logf("explored %d reachable states", len(seen))
 }
 
-// TestPurePredicates evaluates every pure operator on Init.
-// Ensures the registry is non-empty and methods do not panic.
+// TestPurePredicates is the generated pure-gate dual stub.
+// Names come from Decision.tla (SSOT); dual package tests cover production wiring.
 func TestPurePredicates(t *testing.T) {
+	want := []string{
+		"WaitNeeded",
+		"NoSendWhileExhausted",
+	}
 	s := Init()
 	preds := PurePredicates()
-	if len(preds) == 0 {
-		t.Fatal("PurePredicates empty")
+	if len(preds) != len(want) {
+		t.Fatalf("PurePredicates len=%d want %d", len(preds), len(want))
 	}
+	got := make(map[string]bool, len(preds))
 	for _, p := range preds {
+		if p.Name == "" {
+			t.Fatal("empty PurePredicate.Name")
+		}
+		if got[p.Name] {
+			t.Fatalf("duplicate pure name %q", p.Name)
+		}
+		got[p.Name] = true
 		t.Run(p.Name, func(t *testing.T) {
 			_ = p.Check(s) // must not panic
 		})
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Fatalf("missing pure %q in PurePredicates()", name)
+		}
 	}
 }

--- a/pkg/logparse/loggroups_decision_dual_test.go
+++ b/pkg/logparse/loggroups_decision_dual_test.go
@@ -60,17 +60,3 @@ func TestSplitGroupsStrayEndgroupNoUnderflow(t *testing.T) {
 	assert.Equal(t, "Tail", groups[0].name)
 }
 
-func TestLogGroupsPurePredicatesRegistry(t *testing.T) {
-	t.Parallel()
-	preds := loggroupsspec.PurePredicates()
-	require.NotEmpty(t, preds)
-	s := loggroupsspec.Init()
-	var saw bool
-	for _, p := range preds {
-		_ = p.Check(s)
-		if p.Name == "Inv_DepthNonNeg" {
-			saw = true
-		}
-	}
-	assert.True(t, saw)
-}

--- a/pkg/logparse/loggroupsspec/spec_test.go
+++ b/pkg/logparse/loggroupsspec/spec_test.go
@@ -42,17 +42,33 @@ func TestBFSReachability(t *testing.T) {
 	t.Logf("explored %d reachable states", len(seen))
 }
 
-// TestPurePredicates evaluates every pure operator on Init.
-// Ensures the registry is non-empty and methods do not panic.
+// TestPurePredicates is the generated pure-gate dual stub.
+// Names come from Decision.tla (SSOT); dual package tests cover production wiring.
 func TestPurePredicates(t *testing.T) {
+	want := []string{
+		"Inv_DepthNonNeg",
+	}
 	s := Init()
 	preds := PurePredicates()
-	if len(preds) == 0 {
-		t.Fatal("PurePredicates empty")
+	if len(preds) != len(want) {
+		t.Fatalf("PurePredicates len=%d want %d", len(preds), len(want))
 	}
+	got := make(map[string]bool, len(preds))
 	for _, p := range preds {
+		if p.Name == "" {
+			t.Fatal("empty PurePredicate.Name")
+		}
+		if got[p.Name] {
+			t.Fatalf("duplicate pure name %q", p.Name)
+		}
+		got[p.Name] = true
 		t.Run(p.Name, func(t *testing.T) {
 			_ = p.Check(s) // must not panic
 		})
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Fatalf("missing pure %q in PurePredicates()", name)
+		}
 	}
 }

--- a/pkg/store/sync_bounds_decision_dual_test.go
+++ b/pkg/store/sync_bounds_decision_dual_test.go
@@ -117,17 +117,3 @@ func TestSyncBoundsDecisionDual_AgainstStore(t *testing.T) {
 	}
 }
 
-func TestSyncBoundsPurePredicatesRegistry(t *testing.T) {
-	t.Parallel()
-	preds := syncboundsspec.PurePredicates()
-	require.NotEmpty(t, preds)
-	s := syncboundsspec.Init()
-	var saw bool
-	for _, p := range preds {
-		_ = p.Check(s)
-		if p.Name == "NoStaleAccepted" {
-			saw = true
-		}
-	}
-	assert.True(t, saw)
-}

--- a/pkg/store/syncboundsspec/spec_test.go
+++ b/pkg/store/syncboundsspec/spec_test.go
@@ -51,17 +51,33 @@ func TestBFSReachability(t *testing.T) {
 	t.Logf("explored %d reachable states", len(seen))
 }
 
-// TestPurePredicates evaluates every pure operator on Init.
-// Ensures the registry is non-empty and methods do not panic.
+// TestPurePredicates is the generated pure-gate dual stub.
+// Names come from Decision.tla (SSOT); dual package tests cover production wiring.
 func TestPurePredicates(t *testing.T) {
+	want := []string{
+		"NoStaleAccepted",
+	}
 	s := Init()
 	preds := PurePredicates()
-	if len(preds) == 0 {
-		t.Fatal("PurePredicates empty")
+	if len(preds) != len(want) {
+		t.Fatalf("PurePredicates len=%d want %d", len(preds), len(want))
 	}
+	got := make(map[string]bool, len(preds))
 	for _, p := range preds {
+		if p.Name == "" {
+			t.Fatal("empty PurePredicate.Name")
+		}
+		if got[p.Name] {
+			t.Fatalf("duplicate pure name %q", p.Name)
+		}
+		got[p.Name] = true
 		t.Run(p.Name, func(t *testing.T) {
 			_ = p.Check(s) // must not panic
 		})
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Fatalf("missing pure %q in PurePredicates()", name)
+		}
 	}
 }

--- a/pkg/tui/results/tuireload_decision_dual_test.go
+++ b/pkg/tui/results/tuireload_decision_dual_test.go
@@ -47,17 +47,3 @@ func TestLogFetchResultFreshMatchesDecision(t *testing.T) {
 	assert.False(t, logFetchResultFresh(0, 1, 0, 0))
 }
 
-func TestTuiReloadPurePredicatesRegistry(t *testing.T) {
-	t.Parallel()
-	preds := tuireloadspec.PurePredicates()
-	require.NotEmpty(t, preds)
-	s := tuireloadspec.Init()
-	var saw bool
-	for _, p := range preds {
-		_ = p.Check(s)
-		if p.Name == "NoStaleAccepted" {
-			saw = true
-		}
-	}
-	assert.True(t, saw)
-}

--- a/pkg/tui/results/tuireloadspec/spec_test.go
+++ b/pkg/tui/results/tuireloadspec/spec_test.go
@@ -54,17 +54,33 @@ func TestBFSReachability(t *testing.T) {
 	t.Logf("explored %d reachable states", len(seen))
 }
 
-// TestPurePredicates evaluates every pure operator on Init.
-// Ensures the registry is non-empty and methods do not panic.
+// TestPurePredicates is the generated pure-gate dual stub.
+// Names come from Decision.tla (SSOT); dual package tests cover production wiring.
 func TestPurePredicates(t *testing.T) {
+	want := []string{
+		"NoStaleAccepted",
+	}
 	s := Init()
 	preds := PurePredicates()
-	if len(preds) == 0 {
-		t.Fatal("PurePredicates empty")
+	if len(preds) != len(want) {
+		t.Fatalf("PurePredicates len=%d want %d", len(preds), len(want))
 	}
+	got := make(map[string]bool, len(preds))
 	for _, p := range preds {
+		if p.Name == "" {
+			t.Fatal("empty PurePredicate.Name")
+		}
+		if got[p.Name] {
+			t.Fatalf("duplicate pure name %q", p.Name)
+		}
+		got[p.Name] = true
 		t.Run(p.Name, func(t *testing.T) {
 			_ = p.Check(s) // must not panic
 		})
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Fatalf("missing pure %q in PurePredicates()", name)
+		}
 	}
 }

--- a/specs/DECISION_CORES.md
+++ b/specs/DECISION_CORES.md
@@ -71,7 +71,8 @@ Checks:
 - Decision.tla present for each core
 - Generated `pkg/.../*spec/spec.go` with `PurePredicates()` registry
 - Production pure-gate symbols in non-test sources
-- Dual test files present (semantic duals + registry smoke)
+- Dual test files present (production ↔ decision semantics)
+- Pure registry dual-stub is **generated** (`TestPurePredicates` in `*spec`)
 - Optional: `SPECGEN_CHECK_REGEN=1` → regenerate + no-diff
 
 Generated pure API (per `*spec` package):
@@ -79,7 +80,8 @@ Generated pure API (per `*spec` package):
 ```go
 func (s State) WaitNeeded() bool          // example pure gate
 func PurePredicates() []PurePredicate     // enumerate all pure gates
-// TestPurePredicates — generated smoke on Init
+// TestPurePredicates — generated dual-stub: exact names + no panic on Init
+// (do not re-list PurePredicates in production dual tests)
 ```
 
 ```bash

--- a/tools/specgen/codegen.go
+++ b/tools/specgen/codegen.go
@@ -542,24 +542,45 @@ func (cg *CodeGen) GenerateTests() string {
 	return b.String()
 }
 
-// writeTestPurePredicates smoke-tests every PurePredicates() entry on Init
-// (must not panic). Duals still own semantic correctness.
+// writeTestPurePredicates is the generated dual-stub for pure gates:
+// exact name set from Decision.tla + no-panic on Init.
+// Production duals only need semantic prod↔decision checks (not registry smoke).
 func (cg *CodeGen) writeTestPurePredicates(b *strings.Builder) {
-	if len(cg.purePredicates()) == 0 {
+	preds := cg.purePredicates()
+	if len(preds) == 0 {
 		return
 	}
-	b.WriteString(`// TestPurePredicates evaluates every pure operator on Init.
-// Ensures the registry is non-empty and methods do not panic.
+	b.WriteString(`// TestPurePredicates is the generated pure-gate dual stub.
+// Names come from Decision.tla (SSOT); dual package tests cover production wiring.
 func TestPurePredicates(t *testing.T) {
+	want := []string{
+`)
+	for _, p := range preds {
+		fmt.Fprintf(b, "\t\t%q,\n", p.name)
+	}
+	b.WriteString(`	}
 	s := Init()
 	preds := PurePredicates()
-	if len(preds) == 0 {
-		t.Fatal("PurePredicates empty")
+	if len(preds) != len(want) {
+		t.Fatalf("PurePredicates len=%d want %d", len(preds), len(want))
 	}
+	got := make(map[string]bool, len(preds))
 	for _, p := range preds {
+		if p.Name == "" {
+			t.Fatal("empty PurePredicate.Name")
+		}
+		if got[p.Name] {
+			t.Fatalf("duplicate pure name %q", p.Name)
+		}
+		got[p.Name] = true
 		t.Run(p.Name, func(t *testing.T) {
 			_ = p.Check(s) // must not panic
 		})
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Fatalf("missing pure %q in PurePredicates()", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Item 5: dual stubs from `PurePredicates()` at low cost.

- **specgen** `TestPurePredicates` now pins **exact pure names** from Decision.tla + no-panic
- Dropped 7 hand-written `*PurePredicatesRegistry` dual smokes (duplicated generated tests)
- Dual package tests keep **production ↔ decision** semantics only
- Docs: `specs/DECISION_CORES.md`

## Verify
- `bazel test //tools/decision:up_to_date` + package duals
- `scripts/decision-check.sh`
- `bazel build //:ote`