### PR TITLE
SSOT: logFetchResultFresh → CanFetchAccept + GATES Check

### DIFF
--- a/pkg/tui/results/BUILD.bazel
+++ b/pkg/tui/results/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//pkg/analyzer",
         "//pkg/enrichment",
+        "//pkg/tui/results/tuireloadspec",
         "//pkg/utils",
         "@com_github_charmbracelet_bubbles//key",
         "@com_github_charmbracelet_bubbles//spinner",

--- a/pkg/tui/results/model.go
+++ b/pkg/tui/results/model.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stefanpenner/otel-explorer/pkg/analyzer"
 	"github.com/stefanpenner/otel-explorer/pkg/enrichment"
+	"github.com/stefanpenner/otel-explorer/pkg/tui/results/tuireloadspec"
 	"github.com/stefanpenner/otel-explorer/pkg/utils"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
@@ -399,10 +400,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // logFetchResultFresh is the TuiReloadDecision FetchAccept guard: the result
 // names the in-flight job and was started under the current reloadGen.
-// Spec: specs/tui-reload/decision (FetchAccept / FetchDiscard).
+// Spec: specs/tui-reload/decision FetchAccept → tuireloadspec.CanFetchAccept.
+// SSOT: production calls the generated guard (msg job must match in-flight).
 // Dual: TestLogFetchResultFreshMatchesDecision.
 func logFetchResultFresh(msgJob, fetchingJob int64, msgGen, reloadGen int) bool {
-	return msgJob != 0 && msgJob == fetchingJob && msgGen == reloadGen
+	if msgJob == 0 || msgJob != fetchingJob {
+		return false
+	}
+	// Encode result gen into FetchGen; CanFetchAccept is gen match + job set.
+	return tuireloadspec.State{
+		FetchJob:  fetchingJob,
+		FetchGen:  int64(msgGen),
+		ReloadGen: int64(reloadGen),
+	}.CanFetchAccept()
 }
 
 // handleLogFetchResult processes a completed inline log fetch. Stale results

--- a/specs/gha-lifecycle/GATES.md
+++ b/specs/gha-lifecycle/GATES.md
@@ -11,4 +11,4 @@ Load this for code changes. Full TLC for multi-attempt runs: `GhaLifecycle.tla`.
 
 **Rule:** pending never failed; queue only non-pending (and not skipped/cancelled).
 
-**Check:** `bazel test //pkg/analyzer:analyzer_test --test_filter=GhaLifecycle|Pure`
+**Check:** `scripts/decision-check.sh`

--- a/specs/log-groups/GATES.md
+++ b/specs/log-groups/GATES.md
@@ -12,4 +12,4 @@ Load this for code changes. Full TLC for timestamps/gaps: `LogGroups.tla`.
 Open stays parametric (prod unbounded depth; core MaxDepth=3).  
 **Rule:** never underflow depth (stray endgroup is no-op).
 
-**Check:** `bazel test //pkg/logparse:logparse_test --test_filter=GroupStack|LogGroups|Pure`
+**Check:** `scripts/decision-check.sh`

--- a/specs/rate-limit/GATES.md
+++ b/specs/rate-limit/GATES.md
@@ -11,4 +11,4 @@ Load this for code changes. Full TLC only for multi-goroutine races: `RateLimit.
 **SSOT:** production `rateLimitWaitNeeded` calls generated `WaitNeeded`.  
 **Rule:** after sleep, recheck; do not fire blind while still exhausted.
 
-**Check:** `bazel test //pkg/githubapi:githubapi_test --test_filter=RateLimit|Pure`
+**Check:** `scripts/decision-check.sh`

--- a/specs/span-tree/GATES.md
+++ b/specs/span-tree/GATES.md
@@ -9,4 +9,4 @@ Load this for code changes. Full TLC for pipeline/cycles: `SpanTree.tla`.
 
 **Rule:** when group is exactly {1 API, 1 runner}, drop the API span.
 
-**Check:** `bazel test //pkg/analyzer:analyzer_test --test_filter=DropAPI|Dedup|SpanTree|Pure`
+**Check:** `scripts/decision-check.sh`

--- a/specs/sync-bounds/GATES.md
+++ b/specs/sync-bounds/GATES.md
@@ -9,4 +9,4 @@ Load this for code changes. Full TLC for multi-run sync: `SyncBounds.tla`.
 
 **Rule:** accept if `incoming==0` (unknown) or `incoming==stored`. SQL is atomic twin.
 
-**Check:** `bazel test //pkg/store:store_test --test_filter=SyncBounds|Pure`
+**Check:** `scripts/decision-check.sh`

--- a/specs/timing-clamp/GATES.md
+++ b/specs/timing-clamp/GATES.md
@@ -9,4 +9,4 @@ Load this for code changes. Full TLC for pipeline faults: `TimingClamp.tla`.
 
 **SSOT:** production calls generated `DoClamp` (not a hand formula).
 
-**Check:** `bazel test //pkg/analyzer:analyzer_test --test_filter=Clamp|Pure`
+**Check:** `scripts/decision-check.sh`

--- a/specs/tui-reload/GATES.md
+++ b/specs/tui-reload/GATES.md
@@ -4,9 +4,10 @@ Load this for code changes. Full TLC only for race redesign: `TuiReload.tla`.
 
 | Gate | Production | Decision | Generated pure |
 |------|------------|----------|----------------|
-| Fresh log-fetch result | `logFetchResultFresh` | FetchAccept / FetchDiscard | `NoStaleAccepted` |
+| Fresh log-fetch result | `logFetchResultFresh` → **CanFetchAccept** | FetchAccept / FetchDiscard | `NoStaleAccepted` |
 | Package | `pkg/tui/results` | `decision/Decision.tla` | `tuireloadspec` |
 
-**Rule:** accept only if `msgJob == fetchingJob` and `msgGen == reloadGen`.
+**SSOT:** production calls generated `CanFetchAccept` (after msg job match).  
+**Rule:** accept only if job matches in-flight and `msgGen == reloadGen`.
 
-**Check:** `bazel test //pkg/tui/results:results_test --test_filter=LogFetch|TuiReload|Pure`
+**Check:** `scripts/decision-check.sh`


### PR DESCRIPTION
## Summary
Continue item 4 (prod → generated):

- `logFetchResultFresh` → **`tuireloadspec.CanFetchAccept`** (job match then gen gate)
- All 7 `specs/*/GATES.md` **Check** lines → `scripts/decision-check.sh` (one agent path)

Same pattern as DoClamp / WaitNeeded / CanClose.

## Verify
- `bazel test //pkg/tui/results:results_test //tools/decision:up_to_date`
- `scripts/decision-check.sh`
- `bazel build //:ote`