### PR TITLE
SSOT: acceptJobsAttempt → AcceptAllowed

### DIFF
--- a/pkg/store/BUILD.bazel
+++ b/pkg/store/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/analyzer",
         "//pkg/githubapi",
+        "//pkg/store/syncboundsspec",
         "@org_modernc_sqlite//:sqlite",
     ],
 )

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/stefanpenner/otel-explorer/pkg/analyzer"
+	"github.com/stefanpenner/otel-explorer/pkg/store/syncboundsspec"
 	_ "modernc.org/sqlite"
 )
 
@@ -370,11 +371,13 @@ func timeOf(ms int64) time.Time {
 
 // acceptJobsAttempt is the pure UpsertJobs attempt gate.
 // SQL form: WHERE (?=0 OR run_attempt=?) — attempt 0 = unknown, always accept.
-// Spec: specs/sync-bounds/decision (OfferNewer accept / OfferOlder reject).
-// The SQL remains the atomic gate; this helper is the decision-layer mirror
-// used by dual tests and docs so the pure rule cannot drift silently.
+// Spec: specs/sync-bounds/decision AcceptAllowed → syncboundsspec.AcceptAllowed.
+// SSOT: production calls the generated pure; SQL remains the atomic twin.
 func acceptJobsAttempt(storedAttempt, incomingAttempt int64) bool {
-	return incomingAttempt == 0 || incomingAttempt == storedAttempt
+	return syncboundsspec.State{
+		StoredAttempt:   storedAttempt,
+		IncomingAttempt: incomingAttempt,
+	}.AcceptAllowed()
 }
 
 // UpsertJobs replaces one run's jobs and marks the run's job detail as

--- a/pkg/store/syncboundsspec/spec.go
+++ b/pkg/store/syncboundsspec/spec.go
@@ -118,6 +118,11 @@ func (s State) NoStaleAccepted() bool {
 	return (!(s.Accepted) || (s.IncomingAttempt >= s.StoredAttempt))
 }
 
+// AcceptAllowed is the pure TLA+ operator AcceptAllowed.
+func (s State) AcceptAllowed() bool {
+	return s.IncomingAttempt == 0 || s.IncomingAttempt == s.StoredAttempt
+}
+
 // PurePredicate is a named pure decision gate (no state change).
 type PurePredicate struct {
 	Name  string
@@ -128,6 +133,7 @@ type PurePredicate struct {
 func PurePredicates() []PurePredicate {
 	return []PurePredicate{
 		{Name: "NoStaleAccepted", Check: State.NoStaleAccepted},
+		{Name: "AcceptAllowed", Check: State.AcceptAllowed},
 	}
 }
 

--- a/pkg/store/syncboundsspec/spec_test.go
+++ b/pkg/store/syncboundsspec/spec_test.go
@@ -56,6 +56,7 @@ func TestBFSReachability(t *testing.T) {
 func TestPurePredicates(t *testing.T) {
 	want := []string{
 		"NoStaleAccepted",
+		"AcceptAllowed",
 	}
 	s := Init()
 	preds := PurePredicates()

--- a/specs/sync-bounds/GATES.md
+++ b/specs/sync-bounds/GATES.md
@@ -4,9 +4,10 @@ Load this for code changes. Full TLC for multi-run sync: `SyncBounds.tla`.
 
 | Gate | Production | Decision | Generated pure |
 |------|------------|----------|----------------|
-| Accept jobs write | `acceptJobsAttempt` (+ SQL) | OfferNewer / OfferOlder | `NoStaleAccepted` |
+| Accept jobs write | `acceptJobsAttempt` → **AcceptAllowed** (+ SQL) | OfferNewer / OfferOlder | `AcceptAllowed`, `NoStaleAccepted` |
 | Package | `pkg/store` | `decision/Decision.tla` | `syncboundsspec` |
 
+**SSOT:** production `acceptJobsAttempt` calls generated `AcceptAllowed`.  
 **Rule:** accept if `incoming==0` (unknown) or `incoming==stored`. SQL is atomic twin.
 
 **Check:** `scripts/decision-check.sh`

--- a/specs/sync-bounds/decision/Decision.tla
+++ b/specs/sync-bounds/decision/Decision.tla
@@ -96,6 +96,11 @@ TypeOK ==
 NoStaleAccepted ==
   accepted => incomingAttempt >= storedAttempt
 
+\* Production pure acceptJobsAttempt(stored, incoming):
+\* accept when incoming is 0 (unknown) or equals stored.
+AcceptAllowed ==
+  incomingAttempt = 0 \/ incomingAttempt = storedAttempt
+
 \* Bait: "never accepts any write" - MUST FAIL after OfferNewer.
 \* Proves TLC explores Store then OfferNewer.
 BaitNeverAccepted == ~accepted

--- a/specs/sync-bounds/decision/README.md
+++ b/specs/sync-bounds/decision/README.md
@@ -22,6 +22,7 @@ Pin the pure guard so production code cannot drift:
 | `Store1` / `Store2` / `Store3` | `UpsertRuns` writes `run_attempt` |
 | `OfferNewer` | `UpsertJobs` with `attempt == run_attempt` → accept |
 | `OfferOlder` | `UpsertJobs` with stale attempt → discard (Bug=TRUE: stomp) |
+| pure `AcceptAllowed` | production `acceptJobsAttempt` (SSOT) |
 
 ## Correct sequence (no stomp)
 


### PR DESCRIPTION
## Summary
Item 4 continue: sync-bounds prod gate → generated pure.

- Decision.tla: pure **`AcceptAllowed`** (`incoming=0 ∨ incoming=stored`)
- Production `acceptJobsAttempt` → `syncboundsspec.AcceptAllowed`
- GATES / decision README updated
- SQL UpsertJobs remains atomic twin

## Verify
- `scripts/check-specs.sh sync-bounds` (incl. duals)
- `bazel test //pkg/store:store_test //tools/decision:up_to_date`
- `scripts/decision-check.sh`
- `bazel build //:ote`