### PR TITLE
specgen bool parens + gha countsFailed SSOT

### DIFF
--- a/pkg/analyzer/BUILD.bazel
+++ b/pkg/analyzer/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
     importpath = "github.com/stefanpenner/otel-explorer/pkg/analyzer",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/analyzer/ghalifecyclespec",
         "//pkg/analyzer/timingclampspec",
         "//pkg/enrichment",
         "//pkg/githubapi",

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/stefanpenner/otel-explorer/pkg/analyzer/ghalifecyclespec"
 	"github.com/stefanpenner/otel-explorer/pkg/analyzer/timingclampspec"
 	"github.com/stefanpenner/otel-explorer/pkg/githubapi"
 	"github.com/stefanpenner/otel-explorer/pkg/utils"
@@ -820,18 +821,26 @@ func isJobPending(job githubapi.Job) bool {
 }
 
 // countsFailed is the FailedJobs gate: not pending AND (failure|timed_out).
-// Spec: specs/gha-lifecycle/decision ClassifyFailed (Bug=FALSE).
+// Spec: specs/gha-lifecycle/decision ClassifyFailed → CanClassifyFailed.
+// SSOT: production calls the generated guard (hasCompletedAt = !pending).
 func countsFailed(job githubapi.Job) bool {
-	return !isJobPending(job) &&
-		(job.Conclusion == "failure" || job.Conclusion == "timed_out")
+	return ghalifecyclespec.State{
+		HasCompletedAt: !isJobPending(job),
+		Conclusion:     job.Conclusion,
+	}.CanClassifyFailed()
 }
 
 // countsQueue is the queue-time / Queued-span gate: not pending and not
 // skipped/cancelled. Callers also require CreatedAt present for a sample.
-// Spec: specs/gha-lifecycle/decision ClassifyQueue (Bug=FALSE).
+// Spec: specs/gha-lifecycle/decision ClassifyQueue (pending half via CanClassifyQueue).
+// Conclusion filter stays here (decision core does not model skip/cancel).
 func countsQueue(job githubapi.Job) bool {
-	return !isJobPending(job) &&
-		job.Conclusion != "skipped" && job.Conclusion != "cancelled"
+	if job.Conclusion == "skipped" || job.Conclusion == "cancelled" {
+		return false
+	}
+	return ghalifecyclespec.State{
+		HasCompletedAt: !isJobPending(job),
+	}.CanClassifyQueue()
 }
 
 // clampSpanToParent forces a child span into its parent's window: start

--- a/pkg/analyzer/gha_lifecycle_decision_dual_test.go
+++ b/pkg/analyzer/gha_lifecycle_decision_dual_test.go
@@ -129,6 +129,12 @@ func TestGhaLifecycleDecisionDual_Table(t *testing.T) {
 			wantPending: true, wantFailed: false, wantQueue: false,
 		},
 		{
+			// Specgen bool-paren fix: pending timed_out must not CanClassifyFailed.
+			name: "completed timed_out no ts (pending)",
+			status: "completed", completedAt: "", conclusion: "timed_out",
+			wantPending: true, wantFailed: false, wantQueue: false,
+		},
+		{
 			name: "completed failure with ts",
 			status: "completed", completedAt: "2026-01-01T00:00:00Z", conclusion: "failure",
 			wantPending: false, wantFailed: true, wantQueue: true,

--- a/pkg/analyzer/ghalifecyclespec/spec.go
+++ b/pkg/analyzer/ghalifecyclespec/spec.go
@@ -30,7 +30,7 @@ func Init() State {
 
 // CanClassifyPending is the guard for the ClassifyPending action.
 func (s State) CanClassifyPending() bool {
-	return !(s.HasCompletedAt) && !(s.CountedPending)
+	return (!(s.HasCompletedAt) && !(s.CountedPending))
 }
 
 // ClassifyPending applies the ClassifyPending action, returning a new state.
@@ -41,7 +41,7 @@ func (s State) ClassifyPending() State {
 
 // CanClassifyFailed is the guard for the ClassifyFailed action.
 func (s State) CanClassifyFailed() bool {
-	return false || s.HasCompletedAt && s.Conclusion == "failure" || s.Conclusion == "timed_out" && !(s.CountedFailed)
+	return (((false || s.HasCompletedAt) && (s.Conclusion == "failure" || s.Conclusion == "timed_out")) && !(s.CountedFailed))
 }
 
 // ClassifyFailed applies the ClassifyFailed action, returning a new state.
@@ -52,7 +52,7 @@ func (s State) ClassifyFailed() State {
 
 // CanClassifyQueue is the guard for the ClassifyQueue action.
 func (s State) CanClassifyQueue() bool {
-	return false || s.HasCompletedAt && !(s.QueueCounted)
+	return ((false || s.HasCompletedAt) && !(s.QueueCounted))
 }
 
 // ClassifyQueue applies the ClassifyQueue action, returning a new state.

--- a/pkg/analyzer/spantreespec/spec.go
+++ b/pkg/analyzer/spantreespec/spec.go
@@ -28,7 +28,7 @@ func Init() State {
 
 // CanSeeAPI is the guard for the SeeAPI action.
 func (s State) CanSeeAPI() bool {
-	return !(s.Done) && !(s.HaveAPI)
+	return (!(s.Done) && !(s.HaveAPI))
 }
 
 // SeeAPI applies the SeeAPI action, returning a new state.
@@ -39,7 +39,7 @@ func (s State) SeeAPI() State {
 
 // CanSeeRunner is the guard for the SeeRunner action.
 func (s State) CanSeeRunner() bool {
-	return !(s.Done) && !(s.HaveRunner)
+	return (!(s.Done) && !(s.HaveRunner))
 }
 
 // SeeRunner applies the SeeRunner action, returning a new state.
@@ -50,20 +50,20 @@ func (s State) SeeRunner() State {
 
 // CanDedupChoose is the guard for the DedupChoose action.
 func (s State) CanDedupChoose() bool {
-	return !(s.Done) && specgenIf(s.HaveAPI, true, s.HaveRunner)
+	return (!(s.Done) && specgenIf(s.HaveAPI, true, s.HaveRunner))
 }
 
 // DedupChoose applies the DedupChoose action, returning a new state.
 func (s State) DedupChoose() State {
 	pre := s
 	s.Done = true
-	s.Kept = specgenIf(pre.HaveAPI && pre.HaveRunner, "runner", specgenIf(pre.HaveRunner, "runner", "api"))
+	s.Kept = specgenIf((pre.HaveAPI && pre.HaveRunner), "runner", specgenIf(pre.HaveRunner, "runner", "api"))
 	return s
 }
 
 // CanDedupBug is the guard for the DedupBug action.
 func (s State) CanDedupBug() bool {
-	return false && !(s.Done) && s.HaveAPI && s.HaveRunner
+	return (((false && !(s.Done)) && s.HaveAPI) && s.HaveRunner)
 }
 
 // DedupBug applies the DedupBug action, returning a new state.
@@ -108,7 +108,7 @@ func (s State) EnabledActions() []string {
 
 // Inv_RunnerWins is the pure TLA+ operator Inv_RunnerWins.
 func (s State) Inv_RunnerWins() bool {
-	return (!(s.Done && s.HaveAPI && s.HaveRunner) || (s.Kept == "runner"))
+	return (!((s.Done && s.HaveAPI) && s.HaveRunner) || (s.Kept == "runner"))
 }
 
 // PurePredicate is a named pure decision gate (no state change).

--- a/pkg/analyzer/timingclampspec/spec.go
+++ b/pkg/analyzer/timingclampspec/spec.go
@@ -48,7 +48,7 @@ func (s State) SetHostile() State {
 
 // CanDoClamp is the guard for the DoClamp action.
 func (s State) CanDoClamp() bool {
-	return s.Phase == "init" && !(false)
+	return (s.Phase == "init" && !(false))
 }
 
 // DoClamp applies the DoClamp action, returning a new state.
@@ -62,7 +62,7 @@ func (s State) DoClamp() State {
 
 // CanBugPassthrough is the guard for the BugPassthrough action.
 func (s State) CanBugPassthrough() bool {
-	return s.Phase == "init" && false
+	return (s.Phase == "init" && false)
 }
 
 // BugPassthrough applies the BugPassthrough action, returning a new state.

--- a/pkg/githubapi/ratelimitspec/spec.go
+++ b/pkg/githubapi/ratelimitspec/spec.go
@@ -30,7 +30,7 @@ func Init() State {
 
 // CanLearnExhausted is the guard for the LearnExhausted action.
 func (s State) CanLearnExhausted() bool {
-	return s.Remaining > 0 && s.Clock < 3
+	return (s.Remaining > 0 && s.Clock < 3)
 }
 
 // LearnExhausted applies the LearnExhausted action, returning a new state.
@@ -43,7 +43,7 @@ func (s State) LearnExhausted() State {
 
 // CanStartSleep is the guard for the StartSleep action.
 func (s State) CanStartSleep() bool {
-	return s.Remaining == 0 && !(s.Sleeping) && s.Clock < s.ResetAt && s.ResetAt > 0
+	return (((s.Remaining == 0 && !(s.Sleeping)) && s.Clock < s.ResetAt) && s.ResetAt > 0)
 }
 
 // StartSleep applies the StartSleep action, returning a new state.
@@ -54,7 +54,7 @@ func (s State) StartSleep() State {
 
 // CanWakeRecheckSend is the guard for the WakeRecheckSend action.
 func (s State) CanWakeRecheckSend() bool {
-	return s.Sleeping && !(s.Remaining == 0 && s.ResetAt > 0 && s.Clock < s.ResetAt)
+	return (s.Sleeping && !((s.Remaining == 0 && s.ResetAt > 0) && s.Clock < s.ResetAt))
 }
 
 // WakeRecheckSend applies the WakeRecheckSend action, returning a new state.
@@ -66,7 +66,7 @@ func (s State) WakeRecheckSend() State {
 
 // CanWakeRecheckResleep is the guard for the WakeRecheckResleep action.
 func (s State) CanWakeRecheckResleep() bool {
-	return !(false) && s.Sleeping && s.Remaining == 0 && s.ResetAt > 0 && s.Clock < s.ResetAt
+	return ((((!(false) && s.Sleeping) && s.Remaining == 0) && s.ResetAt > 0) && s.Clock < s.ResetAt)
 }
 
 // WakeRecheckResleep applies the WakeRecheckResleep action, returning a new state.
@@ -76,15 +76,15 @@ func (s State) WakeRecheckResleep() State {
 
 // CanWakeBugSend is the guard for the WakeBugSend action.
 func (s State) CanWakeBugSend() bool {
-	return false && s.Sleeping
+	return (false && s.Sleeping)
 }
 
 // WakeBugSend applies the WakeBugSend action, returning a new state.
 func (s State) WakeBugSend() State {
 	pre := s
 	s.Sleeping = false
-	s.SentWhileExhausted = pre.Remaining == int64(0) && pre.ResetAt > int64(0) && pre.Clock < pre.ResetAt
-	s.Remaining = specgenIf(pre.Remaining == 0 && pre.ResetAt > 0 && pre.Clock < pre.ResetAt, pre.Remaining, 2)
+	s.SentWhileExhausted = ((pre.Remaining == int64(0) && pre.ResetAt > int64(0)) && pre.Clock < pre.ResetAt)
+	s.Remaining = specgenIf(((pre.Remaining == 0 && pre.ResetAt > 0) && pre.Clock < pre.ResetAt), pre.Remaining, 2)
 	return s
 }
 
@@ -97,13 +97,13 @@ func (s State) CanTick() bool {
 func (s State) Tick() State {
 	pre := s
 	s.Clock = pre.Clock + 1
-	s.Remaining = specgenIf(pre.Remaining == 0 && pre.ResetAt > 0 && pre.Clock+1 >= pre.ResetAt, 2, pre.Remaining)
+	s.Remaining = specgenIf(((pre.Remaining == 0 && pre.ResetAt > 0) && pre.Clock+1 >= pre.ResetAt), 2, pre.Remaining)
 	return s
 }
 
 // CanSendOk is the guard for the SendOk action.
 func (s State) CanSendOk() bool {
-	return s.Remaining > 0 && !(s.Sleeping)
+	return (s.Remaining > 0 && !(s.Sleeping))
 }
 
 // SendOk applies the SendOk action, returning a new state.
@@ -144,7 +144,7 @@ func (s State) EnabledActions() []string {
 
 // WaitNeeded is the pure TLA+ operator WaitNeeded.
 func (s State) WaitNeeded() bool {
-	return s.Remaining == 0 && s.ResetAt > 0 && s.Clock < s.ResetAt
+	return ((s.Remaining == 0 && s.ResetAt > 0) && s.Clock < s.ResetAt)
 }
 
 // NoSendWhileExhausted is the pure TLA+ operator NoSendWhileExhausted.

--- a/pkg/logparse/loggroupsspec/spec.go
+++ b/pkg/logparse/loggroupsspec/spec.go
@@ -22,7 +22,7 @@ func Init() State {
 
 // CanOpen is the guard for the Open action.
 func (s State) CanOpen() bool {
-	return s.Depth >= 0 && s.Depth < 3
+	return (s.Depth >= 0 && s.Depth < 3)
 }
 
 // Open applies the Open action, returning a new state.
@@ -46,7 +46,7 @@ func (s State) Close() State {
 
 // CanCloseBug is the guard for the CloseBug action.
 func (s State) CanCloseBug() bool {
-	return false && s.Depth == 0
+	return (false && s.Depth == 0)
 }
 
 // CloseBug applies the CloseBug action, returning a new state.

--- a/pkg/store/syncboundsspec/spec.go
+++ b/pkg/store/syncboundsspec/spec.go
@@ -28,7 +28,7 @@ func Init() State {
 
 // CanStore1 is the guard for the Store1 action.
 func (s State) CanStore1() bool {
-	return s.Phase == "empty" || s.Phase == "stored"
+	return (s.Phase == "empty" || s.Phase == "stored")
 }
 
 // Store1 applies the Store1 action, returning a new state.
@@ -40,7 +40,7 @@ func (s State) Store1() State {
 
 // CanStore2 is the guard for the Store2 action.
 func (s State) CanStore2() bool {
-	return s.Phase == "empty" || s.Phase == "stored"
+	return (s.Phase == "empty" || s.Phase == "stored")
 }
 
 // Store2 applies the Store2 action, returning a new state.
@@ -52,7 +52,7 @@ func (s State) Store2() State {
 
 // CanStore3 is the guard for the Store3 action.
 func (s State) CanStore3() bool {
-	return s.Phase == "empty" || s.Phase == "stored"
+	return (s.Phase == "empty" || s.Phase == "stored")
 }
 
 // Store3 applies the Store3 action, returning a new state.
@@ -64,7 +64,7 @@ func (s State) Store3() State {
 
 // CanOfferNewer is the guard for the OfferNewer action.
 func (s State) CanOfferNewer() bool {
-	return s.Phase == "stored" && s.StoredAttempt > 0
+	return (s.Phase == "stored" && s.StoredAttempt > 0)
 }
 
 // OfferNewer applies the OfferNewer action, returning a new state.
@@ -78,7 +78,7 @@ func (s State) OfferNewer() State {
 
 // CanOfferOlder is the guard for the OfferOlder action.
 func (s State) CanOfferOlder() bool {
-	return s.Phase == "stored" && s.StoredAttempt > 1
+	return (s.Phase == "stored" && s.StoredAttempt > 1)
 }
 
 // OfferOlder applies the OfferOlder action, returning a new state.
@@ -120,7 +120,7 @@ func (s State) NoStaleAccepted() bool {
 
 // AcceptAllowed is the pure TLA+ operator AcceptAllowed.
 func (s State) AcceptAllowed() bool {
-	return s.IncomingAttempt == 0 || s.IncomingAttempt == s.StoredAttempt
+	return (s.IncomingAttempt == 0 || s.IncomingAttempt == s.StoredAttempt)
 }
 
 // PurePredicate is a named pure decision gate (no state change).

--- a/pkg/tui/results/tuireloadspec/spec.go
+++ b/pkg/tui/results/tuireloadspec/spec.go
@@ -30,7 +30,7 @@ func Init() State {
 
 // CanPressReload is the guard for the PressReload action.
 func (s State) CanPressReload() bool {
-	return false || !(s.IsLoading) && s.ReloadGen < 2
+	return ((false || !(s.IsLoading)) && s.ReloadGen < 2)
 }
 
 // PressReload applies the PressReload action, returning a new state.
@@ -41,7 +41,7 @@ func (s State) PressReload() State {
 
 // CanReloadDone is the guard for the ReloadDone action.
 func (s State) CanReloadDone() bool {
-	return s.IsLoading && s.ReloadGen < 2
+	return (s.IsLoading && s.ReloadGen < 2)
 }
 
 // ReloadDone applies the ReloadDone action, returning a new state.
@@ -54,7 +54,7 @@ func (s State) ReloadDone() State {
 
 // CanPressFetch1 is the guard for the PressFetch1 action.
 func (s State) CanPressFetch1() bool {
-	return !(s.IsLoading) && s.FetchJob == 0
+	return (!(s.IsLoading) && s.FetchJob == 0)
 }
 
 // PressFetch1 applies the PressFetch1 action, returning a new state.
@@ -67,7 +67,7 @@ func (s State) PressFetch1() State {
 
 // CanPressFetch2 is the guard for the PressFetch2 action.
 func (s State) CanPressFetch2() bool {
-	return !(s.IsLoading) && s.FetchJob == 0
+	return (!(s.IsLoading) && s.FetchJob == 0)
 }
 
 // PressFetch2 applies the PressFetch2 action, returning a new state.
@@ -80,7 +80,7 @@ func (s State) PressFetch2() State {
 
 // CanFetchAccept is the guard for the FetchAccept action.
 func (s State) CanFetchAccept() bool {
-	return s.FetchJob != 0 && s.FetchGen == s.ReloadGen
+	return (s.FetchJob != 0 && s.FetchGen == s.ReloadGen)
 }
 
 // FetchAccept applies the FetchAccept action, returning a new state.
@@ -91,7 +91,7 @@ func (s State) FetchAccept() State {
 
 // CanFetchDiscard is the guard for the FetchDiscard action.
 func (s State) CanFetchDiscard() bool {
-	return s.FetchJob != 0 && s.FetchGen != s.ReloadGen
+	return (s.FetchJob != 0 && s.FetchGen != s.ReloadGen)
 }
 
 // FetchDiscard applies the FetchDiscard action, returning a new state.
@@ -102,7 +102,7 @@ func (s State) FetchDiscard() State {
 
 // CanFetchStaleBug is the guard for the FetchStaleBug action.
 func (s State) CanFetchStaleBug() bool {
-	return false && s.FetchJob != 0 && s.FetchGen != s.ReloadGen
+	return ((false && s.FetchJob != 0) && s.FetchGen != s.ReloadGen)
 }
 
 // FetchStaleBug applies the FetchStaleBug action, returning a new state.

--- a/specs/gha-lifecycle/GATES.md
+++ b/specs/gha-lifecycle/GATES.md
@@ -5,10 +5,12 @@ Load this for code changes. Full TLC for multi-attempt runs: `GhaLifecycle.tla`.
 | Gate | Production | Decision | Generated pure |
 |------|------------|----------|----------------|
 | Job still pending | `isJobPending` | ClassifyPending | — |
-| Count as failed | `countsFailed` | ClassifyFailed | `PendingNeverFailed` |
-| Count queue time | `countsQueue` | ClassifyQueue | `QueueOnlyNotPending` |
+| Count as failed | `countsFailed` → **CanClassifyFailed** | ClassifyFailed | `PendingNeverFailed` |
+| Count queue time | `countsQueue` → **CanClassifyQueue** (+ skip/cancel) | ClassifyQueue | `QueueOnlyNotPending` |
 | Package | `pkg/analyzer` | `decision/Decision.tla` | `ghalifecyclespec` |
 
+**SSOT:** fail/queue pending-half via generated guards (`hasCompletedAt = !pending`).  
+Skip/cancel filter stays in production (outside decision domain).  
 **Rule:** pending never failed; queue only non-pending (and not skipped/cancelled).
 
 **Check:** `scripts/decision-check.sh`

--- a/tools/specgen/codegen.go
+++ b/tools/specgen/codegen.go
@@ -2043,9 +2043,13 @@ func (cg *CodeGen) exprToGo(e tla.Expr, locals map[string]string, recv string) s
 			}
 			return fmt.Sprintf("%s != %s", lhs, rhs)
 		case "/\\":
-			return fmt.Sprintf("%s && %s", lhs, rhs)
+			// Always parenthesize: Go && binds tighter than ||, but TLA
+			// conjunction/disjunction are left-nested without shared prec.
+			// Bare "a || b && c || d" reassociates and breaks faithful guards
+			// (e.g. ClassifyFailed: (Bug\/has) /\ (fail\/timeout) /\ ~counted).
+			return fmt.Sprintf("(%s && %s)", lhs, rhs)
 		case "\\/":
-			return fmt.Sprintf("%s || %s", lhs, rhs)
+			return fmt.Sprintf("(%s || %s)", lhs, rhs)
 		case "=>":
 			// TLA+ implication P => Q is !P \/ Q. Guarding a quantifier with a
 			// CONSTANT flag (Guarded => \A ...) compiles to (!flag || forAll(...)).
@@ -2869,9 +2873,13 @@ func (cg *CodeGen) guardToGo(e Expr, recv string) string {
 			}
 			return fmt.Sprintf("%s != %s", lhs, rhs)
 		case "/\\":
-			return fmt.Sprintf("%s && %s", lhs, rhs)
+			// Always parenthesize: Go && binds tighter than ||, but TLA
+			// conjunction/disjunction are left-nested without shared prec.
+			// Bare "a || b && c || d" reassociates and breaks faithful guards
+			// (e.g. ClassifyFailed: (Bug\/has) /\ (fail\/timeout) /\ ~counted).
+			return fmt.Sprintf("(%s && %s)", lhs, rhs)
 		case "\\/":
-			return fmt.Sprintf("%s || %s", lhs, rhs)
+			return fmt.Sprintf("(%s || %s)", lhs, rhs)
 		case "+":
 			return fmt.Sprintf("%s + %s", lhs, rhs)
 		case "-":


### PR DESCRIPTION
## Summary
Accuracy fix in **specgen** + item 4 gha wire.

### Bug
Generated `CanClassifyFailed` was:
```go
false || has && failure || timed_out && !counted
```
Go reassociates `&&` before `||` → **pending timed_out** wrongly enabled.

### Fix
- Parenthesize `/\` and `\/` emissions in both expr paths
- Regen all 7 decision cores
- Dual: pending timed_out must not classify failed
- Prod: `countsFailed` → `CanClassifyFailed`; `countsQueue` pending half → `CanClassifyQueue`

## Verify
- pending timed_out CanClassifyFailed = false
- `bazel test` analyzer + all decision packages + duals
- `scripts/decision-check.sh`
- `bazel build //:ote`