### PR TITLE
SSOT: dropAPI → DedupChoose; canOpen → CanOpen

### DIFF
--- a/pkg/analyzer/BUILD.bazel
+++ b/pkg/analyzer/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/analyzer/ghalifecyclespec",
+        "//pkg/analyzer/spantreespec",
         "//pkg/analyzer/timingclampspec",
         "//pkg/enrichment",
         "//pkg/githubapi",

--- a/pkg/analyzer/dedup.go
+++ b/pkg/analyzer/dedup.go
@@ -1,6 +1,8 @@
 package analyzer
 
 import (
+	"github.com/stefanpenner/otel-explorer/pkg/analyzer/spantreespec"
+
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -59,8 +61,14 @@ func DedupeRunnerSpans(spans []sdktrace.ReadOnlySpan) []sdktrace.ReadOnlySpan {
 // dropAPIForRunnerTwin is the SpanTreeDecision keep rule for the unambiguous
 // {1 API, 1 runner} twin: drop the API span so the runner survives.
 // Spec: specs/span-tree/decision DedupChoose → kept = "runner".
+// SSOT: twin shape runs generated DedupChoose; drop only when kept is runner
+// and this span is the API side.
 func dropAPIForRunnerTwin(apiCount, runnerCount int, thisIsRunner bool) bool {
-	return apiCount == 1 && runnerCount == 1 && !thisIsRunner
+	if apiCount != 1 || runnerCount != 1 {
+		return false // not the unambiguous twin shape
+	}
+	kept := spantreespec.Init().SeeAPI().SeeRunner().DedupChoose().Kept
+	return kept == "runner" && !thisIsRunner
 }
 
 // spanIsRunner reports whether a span was emitted natively by the GitHub Actions

--- a/pkg/logparse/timestamp.go
+++ b/pkg/logparse/timestamp.go
@@ -42,15 +42,18 @@ type groupBlock struct {
 
 // canOpenGroup / canCloseGroup are the LogGroupsDecision stack gates.
 // Spec: specs/log-groups/decision Open / Close (Bug=FALSE forbids Close at 0).
-// maxDepth <= 0 means unbounded (production); the decision core uses MaxDepth=3.
-// canCloseGroup is SSOT via generated CanClose; canOpenGroup stays parametric
-// because production allows unbounded maxDepth (generated CanOpen hardcodes 3).
+// maxDepth <= 0 means unbounded (production splitGroups); MaxDepth=3 uses
+// generated CanOpen. canCloseGroup always SSOT via generated CanClose.
 func canOpenGroup(depth, maxDepth int) bool {
 	if depth < 0 {
 		return false
 	}
 	if maxDepth <= 0 {
-		return true
+		return true // unbounded production (splitGroups)
+	}
+	// Decision MaxDepth=3: SSOT via generated CanOpen; other bounds stay parametric.
+	if maxDepth == 3 {
+		return loggroupsspec.State{Depth: int64(depth)}.CanOpen()
 	}
 	return depth < maxDepth
 }

--- a/specs/log-groups/GATES.md
+++ b/specs/log-groups/GATES.md
@@ -4,12 +4,12 @@ Load this for code changes. Full TLC for timestamps/gaps: `LogGroups.tla`.
 
 | Gate | Production | Decision | Generated pure |
 |------|------------|----------|----------------|
-| May open group | `canOpenGroup` (parametric) | Open | — |
+| May open group | `canOpenGroup` → **CanOpen** (maxDepth=3) | Open | — |
 | May close group | `canCloseGroup` → **CanClose** | Close | `CanClose`, `Inv_DepthNonNeg` |
 | Package | `pkg/logparse` | `decision/Decision.tla` | `loggroupsspec` |
 
-**SSOT:** production `canCloseGroup` calls generated `CanClose`.  
-Open stays parametric (prod unbounded depth; core MaxDepth=3).  
+**SSOT:** close always via `CanClose`; open via `CanOpen` when maxDepth=3.  
+Production `splitGroups` uses unbounded (maxDepth=0).  
 **Rule:** never underflow depth (stray endgroup is no-op).
 
 **Check:** `scripts/decision-check.sh`

--- a/specs/span-tree/GATES.md
+++ b/specs/span-tree/GATES.md
@@ -4,9 +4,10 @@ Load this for code changes. Full TLC for pipeline/cycles: `SpanTree.tla`.
 
 | Gate | Production | Decision | Generated pure |
 |------|------------|----------|----------------|
-| Drop API twin | `dropAPIForRunnerTwin` | DedupChoose | `Inv_RunnerWins` |
+| Drop API twin | `dropAPIForRunnerTwin` → **DedupChoose** | DedupChoose | `Inv_RunnerWins` |
 | Package | `pkg/analyzer` | `decision/Decision.tla` | `spantreespec` |
 
+**SSOT:** twin shape runs generated `DedupChoose`; drop API when `kept=="runner"`.  
 **Rule:** when group is exactly {1 API, 1 runner}, drop the API span.
 
 **Check:** `scripts/decision-check.sh`


### PR DESCRIPTION
## Summary
Finish item 4 leftovers:

| Production | Generated |
|------------|-----------|
| `dropAPIForRunnerTwin` | `SeeAPI`→`SeeRunner`→`DedupChoose` keep |
| `canOpenGroup` (maxDepth=3) | `CanOpen` |

Production `splitGroups` still uses unbounded maxDepth=0.

## Verify
- `bazel test //pkg/analyzer:analyzer_test //pkg/logparse:logparse_test //tools/decision:up_to_date`
- `scripts/decision-check.sh`
- `bazel build //:ote`