### PR TITLE
SSOT: isJobPending → CanClassifyPending + GATES index

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -815,9 +815,12 @@ func conclusionFromJobs(jobs []githubapi.Job) string {
 // isJobPending reports whether a job has not yet run to completion. GitHub
 // can report a completed job with no completed_at (fault); treat it as
 // still pending — the same discipline FailedJobs counting relies on.
-// Spec: specs/gha-lifecycle/decision (~hasCompletedAt / ClassifyPending).
+// Spec: specs/gha-lifecycle/decision ClassifyPending → CanClassifyPending.
+// SSOT: hasCompletedAt = completed with timestamp; pending = generated guard.
 func isJobPending(job githubapi.Job) bool {
-	return job.Status != "completed" || job.CompletedAt == ""
+	return ghalifecyclespec.State{
+		HasCompletedAt: job.Status == "completed" && job.CompletedAt != "",
+	}.CanClassifyPending()
 }
 
 // countsFailed is the FailedJobs gate: not pending AND (failure|timed_out).

--- a/scripts/decision-stack-status.sh
+++ b/scripts/decision-stack-status.sh
@@ -17,7 +17,7 @@ rows=(
   "rate-limit|pkg/githubapi/ratelimitspec|rateLimitWaitNeeded"
   "timing-clamp|pkg/analyzer/timingclampspec|DoClamp(via timingclampspec)"
   "sync-bounds|pkg/store/syncboundsspec|acceptJobsAttempt"
-  "gha-lifecycle|pkg/analyzer/ghalifecyclespec|countsFailed,countsQueue"
+  "gha-lifecycle|pkg/analyzer/ghalifecyclespec|isJobPending,countsFailed,countsQueue"
   "log-groups|pkg/logparse/loggroupsspec|canOpenGroup,canCloseGroup"
   "span-tree|pkg/analyzer/spantreespec|dropAPIForRunnerTwin"
 )

--- a/specs/GATES.md
+++ b/specs/GATES.md
@@ -8,14 +8,14 @@
 **Cites:** production / decision / pure **symbols** only — never `file.go:line`
 (lines rot; GATES + duals are the map).
 
-| Core | GATES | Production package |
-|------|-------|--------------------|
-| tui-reload | [tui-reload/GATES.md](tui-reload/GATES.md) | `pkg/tui/results` |
-| rate-limit | [rate-limit/GATES.md](rate-limit/GATES.md) | `pkg/githubapi` |
-| timing-clamp | [timing-clamp/GATES.md](timing-clamp/GATES.md) | `pkg/analyzer` |
-| sync-bounds | [sync-bounds/GATES.md](sync-bounds/GATES.md) | `pkg/store` |
-| gha-lifecycle | [gha-lifecycle/GATES.md](gha-lifecycle/GATES.md) | `pkg/analyzer` |
-| log-groups | [log-groups/GATES.md](log-groups/GATES.md) | `pkg/logparse` |
-| span-tree | [span-tree/GATES.md](span-tree/GATES.md) | `pkg/analyzer` |
+| Core | GATES | Production package | Prod→gen SSOT |
+|------|-------|--------------------|---------------|
+| tui-reload | [tui-reload/GATES.md](tui-reload/GATES.md) | `pkg/tui/results` | `CanFetchAccept` |
+| rate-limit | [rate-limit/GATES.md](rate-limit/GATES.md) | `pkg/githubapi` | `WaitNeeded` |
+| timing-clamp | [timing-clamp/GATES.md](timing-clamp/GATES.md) | `pkg/analyzer` | `DoClamp` |
+| sync-bounds | [sync-bounds/GATES.md](sync-bounds/GATES.md) | `pkg/store` | `AcceptAllowed` |
+| gha-lifecycle | [gha-lifecycle/GATES.md](gha-lifecycle/GATES.md) | `pkg/analyzer` | `CanClassify*` |
+| log-groups | [log-groups/GATES.md](log-groups/GATES.md) | `pkg/logparse` | `CanOpen`/`CanClose` |
+| span-tree | [span-tree/GATES.md](span-tree/GATES.md) | `pkg/analyzer` | `DedupChoose` |
 
 Inventory: `scripts/decision-stack-status.sh`

--- a/specs/gha-lifecycle/GATES.md
+++ b/specs/gha-lifecycle/GATES.md
@@ -4,12 +4,12 @@ Load this for code changes. Full TLC for multi-attempt runs: `GhaLifecycle.tla`.
 
 | Gate | Production | Decision | Generated pure |
 |------|------------|----------|----------------|
-| Job still pending | `isJobPending` | ClassifyPending | — |
+| Job still pending | `isJobPending` → **CanClassifyPending** | ClassifyPending | — |
 | Count as failed | `countsFailed` → **CanClassifyFailed** | ClassifyFailed | `PendingNeverFailed` |
 | Count queue time | `countsQueue` → **CanClassifyQueue** (+ skip/cancel) | ClassifyQueue | `QueueOnlyNotPending` |
 | Package | `pkg/analyzer` | `decision/Decision.tla` | `ghalifecyclespec` |
 
-**SSOT:** fail/queue pending-half via generated guards (`hasCompletedAt = !pending`).  
+**SSOT:** pending/fail/queue via generated guards.  
 Skip/cancel filter stays in production (outside decision domain).  
 **Rule:** pending never failed; queue only non-pending (and not skipped/cancelled).
 


### PR DESCRIPTION
## Summary
- `isJobPending` → **`CanClassifyPending`** (hasCompletedAt = completed+timestamp)
- All three gha gates now SSOT via generated guards
- `specs/GATES.md` index: **Prod→gen SSOT** column
- stack-status lists `isJobPending`

## Verify
- `bazel test //pkg/analyzer:analyzer_test //tools/decision:up_to_date`
- `scripts/decision-check.sh`
- `bazel build //:ote`