### PR TITLE
Lock prod→gen SSOT in wires + DECISION_CORES

### DIFF
--- a/scripts/verify-decision-wires.sh
+++ b/scripts/verify-decision-wires.sh
@@ -13,17 +13,30 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 # core_name | package path | required symbol
-# Keep in sync with specs/DECISION_CORES.md production column.
+# Keep in sync with specs/DECISION_CORES.md + specs/GATES.md.
 wires=(
   "tui-reload|pkg/tui/results|logFetchResultFresh"
   "rate-limit|pkg/githubapi|rateLimitWaitNeeded"
   "timing-clamp|pkg/analyzer|timingclampspec"
   "sync-bounds|pkg/store|acceptJobsAttempt"
+  "gha-lifecycle|pkg/analyzer|isJobPending"
   "gha-lifecycle|pkg/analyzer|countsFailed"
   "gha-lifecycle|pkg/analyzer|countsQueue"
   "span-tree|pkg/analyzer|dropAPIForRunnerTwin"
   "log-groups|pkg/logparse|canOpenGroup"
   "log-groups|pkg/logparse|canCloseGroup"
+)
+
+# Production package dir | gen package name that must appear in non-test imports.
+# Ensures SSOT (prod calls *spec) rather than a re-inlined formula under the same symbol.
+ssot_imports=(
+  "pkg/tui/results|tuireloadspec"
+  "pkg/githubapi|ratelimitspec"
+  "pkg/analyzer|timingclampspec"
+  "pkg/analyzer|ghalifecyclespec"
+  "pkg/analyzer|spantreespec"
+  "pkg/store|syncboundsspec"
+  "pkg/logparse|loggroupsspec"
 )
 
 gen_pkgs=(
@@ -94,6 +107,27 @@ for row in "${wires[@]}"; do
     echo "  ok $core → $sym"
   else
     echo "  FAIL $core: $sym not in $dir production sources"
+    fail=1
+  fi
+done
+
+echo "--- prod → gen SSOT imports ---"
+for row in "${ssot_imports[@]}"; do
+  IFS='|' read -r dir pkg <<<"$row"
+  found=0
+  while IFS= read -r -d '' f; do
+    case "$f" in
+      *spec/*) continue ;;
+    esac
+    if grep -F -q -- "$pkg" "$f" 2>/dev/null; then
+      found=1
+      break
+    fi
+  done < <(find "$dir" -type f -name '*.go' ! -name '*_test.go' -print0 2>/dev/null)
+  if [ "$found" -eq 1 ]; then
+    echo "  ok $dir imports $pkg"
+  else
+    echo "  FAIL $dir: missing import/use of $pkg (re-inlined formula?)"
     fail=1
   fi
 done

--- a/specs/DECISION_CORES.md
+++ b/specs/DECISION_CORES.md
@@ -55,22 +55,24 @@ scripts/regenerate-decision-cores.sh timing-clamp
 
 ## Cores and production wiring
 
-| Core | Models | Gen package | Production |
-|------|--------|-------------|------------|
-| tui-reload | reload gen + stale fetch discard | `tuireloadspec` | **wired** — `logFetchResultFresh` |
-| rate-limit | wait/recheck after sleep | `ratelimitspec` | **wired** — `rateLimitWaitNeeded` |
-| timing-clamp | clampSpanToParent | `timingclampspec` | **wired** — `DoClamp` |
-| sync-bounds | stale attempt | `syncboundsspec` | **wired** — `acceptJobsAttempt` (SQL twin) |
-| gha-lifecycle | pending/fail/queue gates | `ghalifecyclespec` | **wired** — `countsFailed` / `countsQueue` |
-| log-groups | stack depth | `loggroupsspec` | **wired** — `canOpenGroup` / `canCloseGroup` |
-| span-tree | runner-wins keep | `spantreespec` | **wired** — `dropAPIForRunnerTwin` |
+| Core | Models | Gen package | Production → generated SSOT |
+|------|--------|-------------|-----------------------------|
+| tui-reload | reload gen + stale fetch discard | `tuireloadspec` | `logFetchResultFresh` → `CanFetchAccept` |
+| rate-limit | wait/recheck after sleep | `ratelimitspec` | `rateLimitWaitNeeded` → `WaitNeeded` |
+| timing-clamp | clampSpanToParent | `timingclampspec` | `clampSpanToParent` → `DoClamp` |
+| sync-bounds | stale attempt | `syncboundsspec` | `acceptJobsAttempt` → `AcceptAllowed` (SQL twin) |
+| gha-lifecycle | pending/fail/queue gates | `ghalifecyclespec` | `isJobPending` / `countsFailed` / `countsQueue` → `CanClassify*` |
+| log-groups | stack depth | `loggroupsspec` | `canCloseGroup` → `CanClose`; open → `CanOpen` @ MaxDepth=3 |
+| span-tree | runner-wins keep | `spantreespec` | `dropAPIForRunnerTwin` → `DedupChoose` |
 
-Wire health: `scripts/verify-decision-wires.sh` (also from `check-specs.sh`).
+Day-to-day map: [GATES.md](GATES.md).  
+Wire health: `scripts/decision-check.sh` (includes `verify-decision-wires.sh`).
 
 Checks:
 - Decision.tla present for each core
 - Generated `pkg/.../*spec/spec.go` with `PurePredicates()` registry
 - Production pure-gate symbols in non-test sources
+- Production packages **import** the gen `*spec` module (SSOT, not re-inlined formula)
 - Dual test files present (production ↔ decision semantics)
 - Pure registry dual-stub is **generated** (`TestPurePredicates` in `*spec`)
 - Optional: `SPECGEN_CHECK_REGEN=1` → regenerate + no-diff
@@ -90,9 +92,9 @@ bazel test  //tools/decision:up_to_date     # fail if *spec stale vs Decision.tl
 bazel run   //tools/decision:update         # rewrite committed *spec from .tla
 bazel build //tools/specgen                 # hermetic codegen binary
 
-# Inventory / TLC / duals
+# Lean gate (agents) / inventory / full TLC
+scripts/decision-check.sh                   # wires + decision-tagged tests
 scripts/decision-stack-status.sh
-scripts/verify-decision-wires.sh
 scripts/check-specs.sh                      # TLC full + decision + duals + wires
 scripts/regenerate-decision-cores.sh        # → bazel run //tools/decision:update
 ```


### PR DESCRIPTION
## Summary
Plan items 1–5 are complete; this fire **locks** the SSOT map.

- `DECISION_CORES.md`: production → **generated** symbol column
- `verify-decision-wires.sh`:
  - `isJobPending` wire
  - **prod → gen import** checks (7 packages must use `*spec`)
- Lean path docs → `scripts/decision-check.sh`

Prevents re-inlining a formula while keeping the same production symbol name.

## Verify
- `scripts/verify-decision-wires.sh` / `decision-check.sh`
- `bazel test //tools/decision:up_to_date`
- `bazel build //:ote`