### PR TITLE
Stack status RS column + CI Go↔Rust parity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,9 @@ jobs:
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
 
+    - name: Go↔Rust decision name parity
+      run: scripts/gen-decision-rust.sh --parity-committed
+
     - name: Rust decision cores
       run: env CC=cc RUSTFLAGS='-C linker=/usr/bin/cc' cargo test -p decision_cores
 

--- a/scripts/decision-stack-status.sh
+++ b/scripts/decision-stack-status.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # decision-stack-status.sh — human-readable inventory of the decision-core stack.
 #
-# One row per core: full TLC, decision core, gen package, prod→gen SSOT,
+# One row per core: full TLC, decision core, Go gen, Rust gen, prod→gen SSOT,
 # production symbols. No TLC/JVM required.
 #
 # Usage: scripts/decision-stack-status.sh
@@ -30,10 +30,15 @@ prod_dir_for() {
   echo "${gen%/*}"
 }
 
-printf '%-14s %-4s %-4s %-4s %-6s %-18s %s\n' \
-  "CORE" "FULL" "DEC" "GEN" "IMPORT" "SSOT" "PRODUCTION"
-printf '%-14s %-4s %-4s %-4s %-6s %-18s %s\n' \
-  "----" "----" "---" "---" "------" "----" "----------"
+# core dir name → crates/decision_cores/src/<snake>.rs
+rust_mod_for() {
+  echo "${1//-/_}"
+}
+
+printf '%-14s %-4s %-4s %-4s %-4s %-6s %-18s %s\n' \
+  "CORE" "FULL" "DEC" "GEN" "RS" "IMPORT" "SSOT" "PRODUCTION"
+printf '%-14s %-4s %-4s %-4s %-4s %-6s %-18s %s\n' \
+  "----" "----" "---" "---" "--" "------" "----" "----------"
 
 for row in "${rows[@]}"; do
   core="${row%%|*}"
@@ -54,6 +59,10 @@ for row in "${rows[@]}"; do
   genok="no"
   [ -f "$gen/spec.go" ] && genok="yes"
 
+  rs="no"
+  rsmod="$(rust_mod_for "$core")"
+  [ -f "crates/decision_cores/src/${rsmod}.rs" ] && rs="yes"
+
   # SSOT import: non-test production sources under parent package use *spec name
   import="no"
   pdir="$(prod_dir_for "$gen")"
@@ -68,12 +77,13 @@ for row in "${rows[@]}"; do
     fi
   done < <(find "$pdir" -type f -name '*.go' ! -name '*_test.go' -print0 2>/dev/null)
 
-  printf '%-14s %-4s %-4s %-4s %-6s %-18s %s\n' \
-    "$core" "$full" "$decision" "$genok" "$import" "$ssot" "$prod"
+  printf '%-14s %-4s %-4s %-4s %-4s %-6s %-18s %s\n' \
+    "$core" "$full" "$decision" "$genok" "$rs" "$import" "$ssot" "$prod"
 done
 
 echo
-echo "Legend: FULL=full TLC  DEC=decision/  GEN=committed *spec"
-echo "        IMPORT=prod package imports *spec (SSOT, not re-inlined)"
+echo "Legend: FULL=full TLC  DEC=decision/  GEN=Go *spec  RS=Rust crate module"
+echo "        IMPORT=Go prod package imports *spec (SSOT, not re-inlined)"
 echo "        SSOT=generated symbol production should call"
+echo "        Rust peer: crates/decision_cores (+ gates::* wrappers)"
 echo "Verify: scripts/decision-check.sh · scripts/check-specs.sh"


### PR DESCRIPTION
## Summary
Lean Rust+Go SSOT inventory / CI:

- **`decision-stack-status.sh`**: `RS` column (`crates/decision_cores/src/<core>.rs`)
- **GHA `test`**: `scripts/gen-decision-rust.sh --parity-committed` before cargo duals

## Verify
- `./scripts/decision-stack-status.sh` → RS=yes all 7
- `./scripts/gen-decision-rust.sh --parity-committed` → OK