### PR TITLE
Rust gates: complete gha-lifecycle peer

### DIFF
--- a/crates/decision_cores/src/gates.rs
+++ b/crates/decision_cores/src/gates.rs
@@ -1,12 +1,63 @@
 //! Thin production-style gates over generated decision modules.
 //! Call generated pure/actions — do not re-inline formulas.
 
+use crate::gha_lifecycle;
 use crate::log_groups;
 use crate::rate_limit;
 use crate::span_tree;
 use crate::sync_bounds;
 use crate::timing_clamp;
 use crate::tui_reload;
+
+/// Encode GitHub "completed with timestamp" (Go `status==completed && completedAt!=""`).
+fn gha_has_completed_at(status: &str, completed_at: &str) -> bool {
+    status == "completed" && !completed_at.is_empty()
+}
+
+/// gha-lifecycle: job still pending (→ `can_classify_pending`).
+/// Matches Go `isJobPending`.
+pub fn is_job_pending(status: &str, completed_at: &str) -> bool {
+    gha_lifecycle::State {
+        has_completed_at: gha_has_completed_at(status, completed_at),
+        conclusion: String::from("failure"),
+        counted_pending: false,
+        counted_failed: false,
+        queue_counted: false,
+    }
+    .can_classify_pending()
+}
+
+/// gha-lifecycle: count as failed (→ `can_classify_failed`).
+/// Matches Go `countsFailed` (not pending AND failure|timed_out).
+pub fn counts_failed(status: &str, completed_at: &str, conclusion: &str) -> bool {
+    // Go: HasCompletedAt: !isJobPending(job)
+    let has = !is_job_pending(status, completed_at);
+    gha_lifecycle::State {
+        has_completed_at: has,
+        conclusion: String::from(conclusion),
+        counted_pending: false,
+        counted_failed: false,
+        queue_counted: false,
+    }
+    .can_classify_failed()
+}
+
+/// gha-lifecycle: count for queue sample (→ `can_classify_queue`).
+/// Matches Go `countsQueue` (skip/cancel stay outside the decision core).
+pub fn counts_queue(status: &str, completed_at: &str, conclusion: &str) -> bool {
+    if conclusion == "skipped" || conclusion == "cancelled" {
+        return false;
+    }
+    let has = !is_job_pending(status, completed_at);
+    gha_lifecycle::State {
+        has_completed_at: has,
+        conclusion: String::from(conclusion),
+        counted_pending: false,
+        counted_failed: false,
+        queue_counted: false,
+    }
+    .can_classify_queue()
+}
 
 /// log-groups: may close stack (→ `log_groups::State::can_close`).
 pub fn can_close_group(depth: i64) -> bool {

--- a/crates/decision_cores/tests/gates_dual.rs
+++ b/crates/decision_cores/tests/gates_dual.rs
@@ -4,6 +4,39 @@
 use decision_cores::gates;
 
 #[test]
+fn gha_lifecycle_table() {
+    // Mirror pkg/analyzer/gha_lifecycle_decision_dual_test.go table.
+    let cases: &[(&str, &str, &str, bool, bool, bool)] = &[
+        // status, completed_at, conclusion, pending, failed, queue
+        ("completed", "", "failure", true, false, false),
+        ("completed", "", "timed_out", true, false, false),
+        ("completed", "2026-01-01T00:00:00Z", "failure", false, true, true),
+        ("completed", "2026-01-01T00:00:00Z", "timed_out", false, true, true),
+        ("completed", "2026-01-01T00:00:00Z", "success", false, false, true),
+        ("in_progress", "", "", true, false, false),
+        ("completed", "2026-01-01T00:00:00Z", "skipped", false, false, false),
+        ("completed", "2026-01-01T00:00:00Z", "cancelled", false, false, false),
+    ];
+    for (status, completed_at, conclusion, want_p, want_f, want_q) in cases {
+        assert_eq!(
+            gates::is_job_pending(status, completed_at),
+            *want_p,
+            "pending {status:?} {completed_at:?}"
+        );
+        assert_eq!(
+            gates::counts_failed(status, completed_at, conclusion),
+            *want_f,
+            "failed {status:?} {conclusion:?}"
+        );
+        assert_eq!(
+            gates::counts_queue(status, completed_at, conclusion),
+            *want_q,
+            "queue {status:?} {conclusion:?}"
+        );
+    }
+}
+
+#[test]
 fn rate_limit_wait_needed_table() {
     assert!(!gates::rate_limit_wait_needed(1, true, true));
     assert!(!gates::rate_limit_wait_needed(0, false, true));


### PR DESCRIPTION
## Summary
All other decision cores had Rust `gates::*` wrappers; **gha-lifecycle** did not.

- `is_job_pending` / `counts_failed` / `counts_queue` → generated `can_classify_*`
- Dual table aligned with Go `gha_lifecycle_decision_dual_test`

## Verify
- `cargo test -p decision_cores` → 14 unit + **6** gates + 4 log_groups
- `./scripts/decision-check.sh` → OK