### PR TITLE
Rust peer on check-specs + per-core GATES

### DIFF
--- a/scripts/check-specs.sh
+++ b/scripts/check-specs.sh
@@ -15,11 +15,11 @@
 #
 # Toolchain:
 #   Prefer `tlc` on PATH (dotai CLI). Else fall back to java -cp tla2tools.jar.
-#   Order: SSOT wires + *spec duals first (fast), TLC last (slow).
+#   Order: SSOT wires + *spec duals + Rust peer first (fast), TLC last (slow).
 #   Does not re-codegen by default — use //tools/decision:update.
 #
-# Without TLC toolchain: still runs wires/duals; skips model-check (exit 0 if
-# those pass). Green TLC at these bounds = strong bug hunt, not proof.
+# Without TLC toolchain: still runs wires/duals/Rust parity; skips model-check
+# (exit 0 if those pass). Green TLC at these bounds = strong bug hunt, not proof.
 #
 # Usage: scripts/check-specs.sh [spec-name ...]   # default: all specs
 
@@ -229,6 +229,29 @@ if command -v go >/dev/null 2>&1; then
   done
 else
   echo "go not on PATH — skip dual package tests"
+fi
+
+# Rust peer (same Decision.tla SSOT): name parity + duals when tools present.
+echo
+echo "--- rust peer (Go↔Rust parity + cargo duals) ---"
+if [ -x "$REPO_ROOT/scripts/gen-decision-rust.sh" ]; then
+  if ! "$REPO_ROOT/scripts/gen-decision-rust.sh" --parity-committed; then
+    fail=$((fail + 1))
+  fi
+else
+  echo "scripts/gen-decision-rust.sh missing — skip parity"
+  fail=$((fail + 1))
+fi
+if command -v cargo >/dev/null 2>&1; then
+  if ! env CC=cc RUSTFLAGS='-C linker=/usr/bin/cc' \
+    cargo test -p decision_cores --quiet; then
+    echo "cargo test -p decision_cores FAIL ✗"
+    fail=$((fail + 1))
+  else
+    echo "cargo test -p decision_cores ok"
+  fi
+else
+  echo "cargo not on PATH — skip rust duals"
 fi
 
 if [ "$SKIP_TLC" -eq 1 ]; then

--- a/specs/gha-lifecycle/GATES.md
+++ b/specs/gha-lifecycle/GATES.md
@@ -13,4 +13,5 @@ Load this for code changes. Full TLC for multi-attempt runs: `GhaLifecycle.tla`.
 Skip/cancel filter stays in production (outside decision domain).  
 **Rule:** pending never failed; queue only non-pending (and not skipped/cancelled).
 
+**Rust peer:** `gates::is_job_pending` / `counts_failed` / `counts_queue` → `gha_lifecycle`.  
 **Check:** `scripts/decision-check.sh`

--- a/specs/log-groups/GATES.md
+++ b/specs/log-groups/GATES.md
@@ -12,4 +12,5 @@ Load this for code changes. Full TLC for timestamps/gaps: `LogGroups.tla`.
 Production `splitGroups` uses unbounded (maxDepth=0).  
 **Rule:** never underflow depth (stray endgroup is no-op).
 
+**Rust peer:** `gates::can_open_group` / `can_close_group` → `log_groups` module.  
 **Check:** `scripts/decision-check.sh`

--- a/specs/rate-limit/GATES.md
+++ b/specs/rate-limit/GATES.md
@@ -11,4 +11,5 @@ Load this for code changes. Full TLC only for multi-goroutine races: `RateLimit.
 **SSOT:** production `rateLimitWaitNeeded` calls generated `WaitNeeded`.  
 **Rule:** after sleep, recheck; do not fire blind while still exhausted.
 
+**Rust peer:** `gates::rate_limit_wait_needed` → `rate_limit` module.  
 **Check:** `scripts/decision-check.sh`

--- a/specs/span-tree/GATES.md
+++ b/specs/span-tree/GATES.md
@@ -10,4 +10,5 @@ Load this for code changes. Full TLC for pipeline/cycles: `SpanTree.tla`.
 **SSOT:** twin shape runs generated `DedupChoose`; drop API when `kept=="runner"`.  
 **Rule:** when group is exactly {1 API, 1 runner}, drop the API span.
 
+**Rust peer:** `gates::drop_api_for_runner_twin` → `span_tree` module.  
 **Check:** `scripts/decision-check.sh`

--- a/specs/sync-bounds/GATES.md
+++ b/specs/sync-bounds/GATES.md
@@ -10,4 +10,5 @@ Load this for code changes. Full TLC for multi-run sync: `SyncBounds.tla`.
 **SSOT:** production `acceptJobsAttempt` calls generated `AcceptAllowed`.  
 **Rule:** accept if `incoming==0` (unknown) or `incoming==stored`. SQL is atomic twin.
 
+**Rust peer:** `gates::accept_jobs_attempt` → `sync_bounds` module.  
 **Check:** `scripts/decision-check.sh`

--- a/specs/timing-clamp/GATES.md
+++ b/specs/timing-clamp/GATES.md
@@ -9,4 +9,5 @@ Load this for code changes. Full TLC for pipeline faults: `TimingClamp.tla`.
 
 **SSOT:** production calls generated `DoClamp` (not a hand formula).
 
+**Rust peer:** `gates::clamp_span_to_parent` → `timing_clamp` module.  
 **Check:** `scripts/decision-check.sh`

--- a/specs/tui-reload/GATES.md
+++ b/specs/tui-reload/GATES.md
@@ -10,4 +10,5 @@ Load this for code changes. Full TLC only for race redesign: `TuiReload.tla`.
 **SSOT:** production calls generated `CanFetchAccept` (after msg job match).  
 **Rule:** accept only if job matches in-flight and `msgGen == reloadGen`.
 
+**Rust peer:** `gates::log_fetch_result_fresh` → `tui_reload` module.  
 **Check:** `scripts/decision-check.sh`


### PR DESCRIPTION
## Summary
Lean agent accuracy for Rust+Go peers:

1. **`check-specs.sh`** — after Go duals: `--parity-committed` + `cargo test -p decision_cores` (when present)
2. **Per-core `GATES.md`** — one **Rust peer** line with `gates::*` symbols

## Verify
- `cargo test -p decision_cores` OK
- `check-specs.sh log-groups` → rust peer ok + TLC ok